### PR TITLE
Web-console exe build + Performance tab (power limit, GFX offset, OD PPT)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,65 @@
+name: Build Windows exe
+
+# Builds the Adrenalift Windows executables with PyInstaller.
+#
+# - On every push to main / PR / manual run: uploads the .exe files as a
+#   downloadable workflow *artifact* (grab them from the run's "Artifacts"
+#   section; requires being signed in to GitHub, kept for 90 days).
+# - On pushing a version tag like `v0.1.4`: also publishes a GitHub *Release*
+#   with the .exe files attached, giving a permanent public download link.
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+  workflow_dispatch:        # lets you run it by hand from the Actions tab
+
+permissions:
+  contents: write           # needed to create a Release on tag builds
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Clone the UPP dependency (VBIOS decoding)
+        run: git clone --depth 1 https://github.com/sibradzic/upp.git deps/upp
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build the web console exe
+        run: python -m PyInstaller --noconfirm build_web.spec
+
+      - name: Build the desktop GUI exe
+        run: python -m PyInstaller --noconfirm build.spec
+
+      - name: List build output
+        run: dir dist
+
+      - name: Upload exe artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: adrenalift-windows-exe
+          path: dist/*.exe
+          if-no-files-found: error
+
+      - name: Publish Release (tag builds only)
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" dist/*.exe \
+            --title "Adrenalift ${GITHUB_REF_NAME}" \
+            --generate-notes

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /build
 /dist
 /.cursor
+/profiles
+/settings.json
+/.reg_backup.json
 /src/tools/*
 !/src/tools/__init__.py
 !/src/tools/reg_patch.py

--- a/README.md
+++ b/README.md
@@ -48,6 +48,24 @@ Because the patch lives only in RAM, it is inherently safe to revert — just re
 
 ---
 
+## Downloads (pre-built Windows exe)
+
+GitHub builds the Windows executables automatically (see
+`.github/workflows/build-windows.yml`):
+
+- **Releases** — every version tag (e.g. `v0.1.4`) publishes a
+  [Release](../../releases) with `Adrenalift_Web_x.x_xx.exe` (browser console)
+  and `Adrenalift_x.x_xx.exe` (desktop GUI) attached. This is the permanent,
+  public download link to share.
+- **Latest build (any commit)** — open the
+  [Actions tab](../../actions/workflows/build-windows.yml), click the most
+  recent run, and download the **adrenalift-windows-exe** artifact (requires
+  being signed in to GitHub; artifacts are kept for 90 days).
+
+To cut a new release: push a tag, e.g. `git tag v0.1.5 && git push origin v0.1.5`.
+
+---
+
 ## Quick Start (pre-built)
 
 1. Download the latest `Adrenalift_x.x_xx.exe` from releases.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,49 @@ Because the patch lives only in RAM, it is inherently safe to revert — just re
 
 ---
 
+## Web server (browser front-end)
+
+Adrenalift can also run as a **local web server** instead of the desktop GUI.
+This is handy for headless setups, remote access over your LAN, or simply if
+you prefer a browser. It shares the same overclock engine as the desktop app
+and adds an extended, beginner-friendly help and tooltip system so regular
+users can navigate the controls more easily.
+
+```powershell
+# from a source checkout, after `pip install -r requirements.txt`
+python -m src.web
+# or use the helper launcher on Windows:
+.\web.bat
+```
+
+Then open <http://127.0.0.1:8770> in your browser.
+
+- **Boost Clock** tab — Scan memory, then choose a boost clock and Apply
+  (the same Simple-tab workflow as the desktop app).
+- **Status** tab — read live SMU state, power limit, and DPM clock ranges.
+- **Metrics** tab — live GPU sensor readout (clocks, power, temps, fan, …).
+- **Help** tab — the full set of in-app guides; every control also has a
+  `?` button with a short tip and a plain-language description.
+
+Options:
+
+```text
+python -m src.web --host 0.0.0.0 --port 8770   # expose on the LAN
+```
+
+> The hardware actions (scan/apply/status/metrics) require **Windows** with the
+> AMD driver, the bundled kernel drivers, and **Administrator** privileges —
+> the same as the desktop app. On other platforms (or without elevation) the
+> server still starts and the UI and help remain fully browsable; hardware
+> actions return a clear "engine unavailable" message instead of failing
+> silently.
+>
+> By default the server binds to `127.0.0.1` (localhost only). Only use
+> `--host 0.0.0.0` on a trusted network: anyone who can reach the port can
+> drive the overclock controls.
+
+---
+
 ## Building from Source
 
 ### Prerequisites
@@ -142,6 +185,13 @@ src/
 │   ├── workers.py       # QThread workers (scan, apply, metrics, etc.)
 │   ├── settings.py      # Persistent settings (settings.json)
 │   └── ...
+├── web/                 # Browser front-end (Flask), shares the engine
+│   ├── server.py        # Flask app, REST API, entry point (python -m src.web)
+│   ├── hardware_service.py  # Qt-free engine wrapper (scan/apply/status/metrics)
+│   ├── jobs.py          # Background job manager (progress + log streaming)
+│   ├── tooltips.py      # Extended beginner-friendly tips & help pages
+│   ├── templates/       # index.html
+│   └── static/          # app.js, style.css
 ├── engine/              # Core overclock logic
 │   ├── overclock_engine.py   # Scan, patch, apply, verify, watchdog
 │   ├── od_table.py           # OverDrive table structures & controller

--- a/README.md
+++ b/README.md
@@ -74,12 +74,19 @@ python -m src.web
 
 Then open <http://127.0.0.1:8770> in your browser.
 
+- **Performance** tab — the settings that actually move performance on RDNA4,
+  in one place: the **power limit (W)** (the most reliable win — sent straight
+  to the firmware, no scan needed), a **GFX clock offset**, and an advanced
+  **OverDrive PPT %**. Includes a one-click safe power-limit template.
 - **Boost Clock** tab — Scan memory, then choose a boost clock and Apply
-  (the same Simple-tab workflow as the desktop app).
+  (the same Simple-tab workflow as the desktop app). Tick **Enable OverDrive &
+  metrics (deep scan)** to also locate the GPU DMA buffer, which unlocks the
+  GFX-offset / OD-PPT controls and the live Metrics tab for the session.
 - **Status** tab — read live SMU state, power limit, and DPM clock ranges.
 - **Metrics** tab — live GPU sensor readout (clocks, power, temps, fan, …).
-- **Help** tab — the full set of in-app guides; every control also has a
-  `?` button with a short tip and a plain-language description.
+- **Help** tab — the full set of in-app guides (start with *Performance settings
+  that matter*); every control also has a `?` button with a short tip and a
+  plain-language description.
 
 Options:
 
@@ -156,6 +163,28 @@ python -m PyInstaller --noconfirm build.spec
 ```
 
 The output `.exe` is written to `dist/`.
+
+### Building the web console exe
+
+To ship the **browser front-end** as a standalone executable (instead of the
+desktop GUI), use the web build scripts. The resulting exe starts the local web
+server and opens your browser automatically; it bundles the HTML/CSS/JS assets
+and Flask instead of Qt.
+
+```powershell
+.\build_web.ps1
+```
+
+Or manually:
+
+```bash
+python -m PyInstaller --noconfirm build_web.spec
+```
+
+The output `dist\Adrenalift_Web_x.x_xx.exe` requests admin elevation, starts the
+server on <http://127.0.0.1:8770>, and opens the browser. The same driver files
+in `drivers/` and (optional) `bios/vbios.rom` requirements apply as for the
+desktop build.
 
 ### UPP (Uplift Power Play)
 

--- a/README.md
+++ b/README.md
@@ -74,19 +74,46 @@ python -m src.web
 
 Then open <http://127.0.0.1:8770> in your browser.
 
-- **Performance** tab — the settings that actually move performance on RDNA4,
-  in one place: the **power limit (W)** (the most reliable win — sent straight
-  to the firmware, no scan needed), a **GFX clock offset**, and an advanced
-  **OverDrive PPT %**. Includes a one-click safe power-limit template.
-- **Boost Clock** tab — Scan memory, then choose a boost clock and Apply
-  (the same Simple-tab workflow as the desktop app). Tick **Enable OverDrive &
-  metrics (deep scan)** to also locate the GPU DMA buffer, which unlocks the
-  GFX-offset / OD-PPT controls and the live Metrics tab for the session.
-- **Status** tab — read live SMU state, power limit, and DPM clock ranges.
-- **Metrics** tab — live GPU sensor readout (clocks, power, temps, fan, …).
-- **Help** tab — the full set of in-app guides (start with *Performance settings
-  that matter*); every control also has a `?` button with a short tip and a
-  plain-language description.
+The web console mirrors the desktop app's full feature set, organised into tabs:
+
+- **Performance** — the settings that actually move performance on RDNA4, in
+  one place: the **power limit (W)** (the most reliable win — sent straight to
+  the firmware, no scan needed), a **GFX clock offset**, an advanced
+  **OverDrive PPT %**, and a one-click safe power-limit template. Also hosts the
+  **Profiles** bar (save / load / apply / import / export).
+- **Boost Clock** — Scan memory, then choose a boost clock and Apply (the same
+  Simple-tab workflow as the desktop app). Tick **Enable OverDrive & metrics
+  (deep scan)** to also locate the GPU DMA buffer, which unlocks the OverDrive
+  editor, GFX-offset / OD-PPT controls, and the live Metrics tab for the session.
+- **OverDrive** — the full firmware OverDrive table: per-field clock offsets,
+  voltage maxima, PPT/TDC, fan curve and temperature limits (needs a deep scan).
+- **PowerPlay** — a per-field editor for every decoded field of the driver's
+  cached PowerPlay table; setting a field patches it in RAM (needs a scan).
+- **SMU** — GFX clock min/max limits and a power-saving lock (disable the
+  idle/clock-gating features that cause downclocking).
+- **Escape** — apply OD via the WDDM **D3DKMTEscape** path, which needs no
+  Administrator privileges.
+- **Metrics** — live GPU sensor readout (clocks, power, temps, fan, …).
+- **Status** — live SMU state, power limit, and DPM clock ranges.
+- **System** — the **persistent** registry/ULPS tweaks (see the caveat below).
+- **Help** — the full set of in-app guides (start with *Performance settings
+  that matter* and *Ephemeral by design*); every control also has a `?` button
+  with a short tip and a plain-language description.
+
+### Ephemeral by design
+
+Everything except the **System** tab is **volatile**: the boost-clock patch,
+OverDrive, PowerPlay, SMU and Escape changes all live in RAM / firmware runtime
+state, so **a reboot returns the GPU to stock**. **Profiles** are saved JSON
+recipes you can export/import and re-apply, but they only ever change that
+volatile state — there is no "apply on startup", so the ephemeral guarantee
+holds.
+
+> **The System (registry) tab is the one exception:** those tweaks write to the
+> Windows registry and **survive a reboot**. Adrenalift takes a backup before
+> the first apply, offers a **Restore** button, and auto-restores on a clean
+> server shutdown — but a hard crash or power loss will not auto-revert, so use
+> Restore. Registry tweaks are deliberately kept out of profiles.
 
 Options:
 

--- a/build_web.bat
+++ b/build_web.bat
@@ -1,0 +1,35 @@
+@echo off
+REM Build the Adrenalift WEB CONSOLE exe with PyInstaller (onefile).
+REM Produces dist\Adrenalift_Web_<ver>_<build>.exe -- run it as Administrator.
+REM Requires: pip install -r requirements.txt
+REM Driver files (inpoutx64.dll, WinRing0x64.dll, WinRing0x64.sys) must be in
+REM drivers\ before building.
+
+cd /d "%~dp0"
+
+REM Prefer python, fall back to py launcher (common on Windows)
+where python >nul 2>nul && set PY=python || set PY=py
+
+echo Checking dependencies...
+%PY% -c "import flask, PyInstaller" 2>nul || (
+    echo Installing requirements...
+    %PY% -m pip install -r requirements.txt
+)
+
+echo.
+echo Cleaning previous build cache...
+if exist build rmdir /s /q build
+
+echo Building web console with PyInstaller...
+%PY% -m PyInstaller --noconfirm --clean build_web.spec
+
+if %ERRORLEVEL% EQU 0 (
+    echo.
+    echo Build complete. Output is in dist\ as Adrenalift_Web_*.exe
+    echo Run it as Administrator; it opens your browser at http://127.0.0.1:8770
+    echo.
+    echo Note: Add bios\vbios.rom for VBIOS, or the app falls back to defaults.
+) else (
+    echo Build failed.
+    exit /b 1
+)

--- a/build_web.ps1
+++ b/build_web.ps1
@@ -1,0 +1,50 @@
+# Build the Adrenalift WEB CONSOLE exe with PyInstaller (onefile).
+# Produces dist\Adrenalift_Web_<ver>_<build>.exe -- run it as Administrator.
+# Requires: pip install -r requirements.txt
+# Driver files (inpoutx64.dll, WinRing0x64.dll, WinRing0x64.sys) must be in
+# drivers\ before building.
+
+Set-Location $PSScriptRoot
+
+# ---------------------------------------------------------------------------
+# Bump build number in version.json (shared with the desktop build)
+# ---------------------------------------------------------------------------
+$versionFile = Join-Path $PSScriptRoot "version.json"
+$versionData = Get-Content $versionFile -Raw | ConvertFrom-Json
+$versionData.build = $versionData.build + 1
+$utf8NoBom = New-Object System.Text.UTF8Encoding $false
+[System.IO.File]::WriteAllText($versionFile, ($versionData | ConvertTo-Json), $utf8NoBom)
+$ver   = $versionData.version
+$build = $versionData.build
+$exeName = "Adrenalift_Web_${ver}_${build}"
+Write-Host "Version $ver  Build $build  ->  $exeName.exe"
+
+# Prefer python, fall back to py launcher (common on Windows)
+$py = if (Get-Command python -ErrorAction SilentlyContinue) { "python" } else { "py" }
+
+Write-Host "Checking dependencies..."
+try {
+    & $py -c "import flask, PyInstaller" 2>$null
+} catch {
+    Write-Host "Installing requirements..."
+    & $py -m pip install -r requirements.txt
+}
+
+Write-Host ""
+Write-Host "Cleaning previous build cache..."
+$buildDir = Join-Path $PSScriptRoot "build"
+if (Test-Path $buildDir) { Remove-Item $buildDir -Recurse -Force }
+
+Write-Host "Building web console with PyInstaller..."
+& $py -m PyInstaller --noconfirm --clean build_web.spec
+
+if ($LASTEXITCODE -eq 0) {
+    Write-Host ""
+    Write-Host "Build complete. Output: dist\$exeName.exe"
+    Write-Host "Run it as Administrator; it opens your browser at http://127.0.0.1:8770"
+    Write-Host ""
+    Write-Host "Note: Add bios\vbios.rom for VBIOS, or the app falls back to defaults."
+} else {
+    Write-Host "Build failed."
+    exit 1
+}

--- a/build_web.spec
+++ b/build_web.spec
@@ -75,6 +75,7 @@ a = Analysis(
         "src.web.tooltips",
         "src.web.profiles",
         "src.web.registry_service",
+        "src.web.pp_help",
         # The web layer reaches into a few app/engine modules:
         "src.app.constants",
         "src.app.settings",

--- a/build_web.spec
+++ b/build_web.spec
@@ -73,6 +73,8 @@ a = Analysis(
         "src.web.hardware_service",
         "src.web.jobs",
         "src.web.tooltips",
+        "src.web.profiles",
+        "src.web.registry_service",
         # The web layer reaches into a few app/engine modules:
         "src.app.constants",
         "src.app.settings",

--- a/build_web.spec
+++ b/build_web.spec
@@ -1,0 +1,139 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""
+PyInstaller spec for the Adrenalift WEB CONSOLE (browser front-end).
+
+Builds a single .exe that launches the Flask web server and opens the browser
+(see src/web/exe_entry.py).  Unlike build.spec (the PySide6 desktop GUI) this
+bundle ships the HTML/CSS/JS assets and Flask instead of Qt.
+
+Requires the driver files in drivers/ before building:
+  inpoutx64.dll, WinRing0x64.dll, WinRing0x64.sys
+  (and optionally WinRing0x64_patched.sys).
+At first run the exe copies the drivers next to itself.  Run as Administrator.
+
+Build:  python -m PyInstaller --noconfirm build_web.spec
+"""
+
+import json
+import os
+
+block_cipher = None
+
+# Read version info for exe naming
+_version_path = os.path.join(SPECPATH, "version.json")
+with open(_version_path, "r", encoding="utf-8") as _vf:
+    _version_info = json.load(_vf)
+_exe_name = f"Adrenalift_Web_{_version_info['version']}_{_version_info['build']}"
+
+# Upp package for RDNA4 VBIOS parsing (cloned into deps/)
+upp_src = os.path.join(SPECPATH, "deps", "upp", "src")
+upp_available = os.path.isdir(upp_src)
+
+# Collect InpOut32/WinRing0 driver files from drivers/ if present
+driver_files = []
+drivers_dir = os.path.join(SPECPATH, "drivers")
+driver_names = [
+    "inpoutx64.dll",
+    "WinRing0x64.dll",
+    "WinRing0x64.sys",
+    "WinRing0x64_patched.sys",
+]
+for name in driver_names:
+    path = os.path.join(drivers_dir, name)
+    if os.path.isfile(path):
+        driver_files.append((path, "."))
+
+if not any("inpoutx64" in p for p, _ in driver_files):
+    print("WARNING: inpoutx64.dll not found in drivers/. Copy driver files to drivers/ before building.")
+if not upp_available:
+    print("WARNING: upp package not found at deps/upp/src. Clone it: git clone https://github.com/sibradzic/upp.git deps/upp")
+
+# Web assets (Jinja templates + static JS/CSS) are bundled below via Tree() so
+# the frozen server can serve them.  They unpack under sys._MEIPASS/src/web/...,
+# which create_app() resolves via _resource_dir().
+
+a = Analysis(
+    ["src/web/exe_entry.py"],
+    pathex=[SPECPATH, os.path.join(SPECPATH, "src")] + ([upp_src] if upp_available else []),
+    binaries=[],
+    datas=driver_files + [(_version_path, ".")],
+    hiddenimports=[
+        # Flask stack (usually auto-detected; listed for safety)
+        "flask",
+        "jinja2",
+        "werkzeug",
+        "upp",
+        "upp.decode",
+        "upp.atom_gen",
+        "upp.atom_gen.atombios",
+        "upp.atom_gen.smu_v14_0_2_navi40",
+        "src",
+        "src.web",
+        "src.web.server",
+        "src.web.hardware_service",
+        "src.web.jobs",
+        "src.web.tooltips",
+        # The web layer reaches into a few app/engine modules:
+        "src.app.constants",
+        "src.app.settings",
+        "src.app.help_texts",
+        "src.engine",
+        "src.engine.overclock_engine",
+        "src.engine.od_table",
+        "src.engine.smu",
+        "src.engine.smu_metrics",
+        "src.io",
+        "src.io.mmio",
+        "src.io.vbios_parser",
+        "src.io.vbios_storage",
+        "src.tools",
+        "src.tools.reg_patch",
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    # The web console does not need Qt; excluding it keeps the exe smaller.
+    excludes=["PySide6", "shiboken6", "PyQt5", "PyQt6"],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+# Add the web asset trees to the bundle's data collection.
+a.datas += Tree(
+    os.path.join(SPECPATH, "src", "web", "templates"),
+    prefix=os.path.join("src", "web", "templates"),
+)
+a.datas += Tree(
+    os.path.join(SPECPATH, "src", "web", "static"),
+    prefix=os.path.join("src", "web", "static"),
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name=_exe_name,
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    # Console kept so the server URL + log are visible and Ctrl+C works.
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    uac_admin=True,
+    icon=None,
+    manifest=os.path.join(SPECPATH, "app.manifest"),
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PySide6>=6.5.0
 pyinstaller>=6.0.0
+Flask>=3.0.0

--- a/src/web/__init__.py
+++ b/src/web/__init__.py
@@ -1,0 +1,35 @@
+"""Adrenalift web server package.
+
+Provides a browser-based front-end as an alternative to the PySide6 desktop
+GUI.  The desktop app and the web server share the same overclock engine
+(``src.engine.overclock_engine``); this package only adds an HTTP layer plus a
+job manager and an extended, beginner-friendly help / tooltip system.
+
+Run it with::
+
+    python -m src.web            # http://127.0.0.1:8770
+
+The engine performs Windows-only physical-memory and SMU operations, so the
+hardware actions only work on a Windows host with the required drivers and
+Administrator privileges.  On other platforms the server still starts and the
+UI (including all help and tooltips) remains fully navigable; hardware actions
+report a friendly "engine unavailable" message instead of crashing.
+"""
+
+from __future__ import annotations
+
+__all__ = ["create_app", "main"]
+
+
+def create_app(*args, **kwargs):
+    # Imported lazily so that merely importing the package does not require
+    # Flask to be installed (e.g. when only the help/tooltip data is needed).
+    from src.web.server import create_app as _create_app
+
+    return _create_app(*args, **kwargs)
+
+
+def main(*args, **kwargs):
+    from src.web.server import main as _main
+
+    return _main(*args, **kwargs)

--- a/src/web/__main__.py
+++ b/src/web/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point so the web server can be launched with ``python -m src.web``."""
+
+from src.web.server import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/web/exe_entry.py
+++ b/src/web/exe_entry.py
@@ -1,0 +1,67 @@
+"""Frozen entry point for the Adrenalift web-server executable.
+
+This is the script PyInstaller bundles (see ``build_web.spec``).  It starts the
+Flask server exactly like ``python -m src.web`` but additionally opens the
+user's default browser at the served URL, so double-clicking the ``.exe`` lands
+straight in the web console.
+
+The console window is intentionally kept open: it shows the URL and the live
+server log, and closing it (or Ctrl+C) stops the server.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import threading
+import webbrowser
+
+# Make ``src`` importable both when frozen and when run from a source checkout.
+_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from src.web.server import create_app
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="Adrenalift",
+        description="Adrenalift web console (browser front-end).",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Interface to bind (default: 127.0.0.1, localhost only). "
+        "Use 0.0.0.0 to expose on your LAN -- only on a trusted network.",
+    )
+    parser.add_argument(
+        "--port", type=int, default=8770, help="Port to listen on (default: 8770)."
+    )
+    parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not open a browser window automatically.",
+    )
+    args = parser.parse_args(argv)
+
+    app = create_app()
+
+    # When binding to all interfaces, still open the browser on localhost.
+    browse_host = "127.0.0.1" if args.host in ("0.0.0.0", "::") else args.host
+    url = f"http://{browse_host}:{args.port}"
+
+    print(f"Adrenalift web console running at {url}")
+    print("Keep this window open. Press Ctrl+C to stop the server.")
+
+    if not args.no_browser:
+        # Delay slightly so the server is listening before the browser opens.
+        threading.Timer(1.2, lambda: webbrowser.open(url)).start()
+
+    app.run(host=args.host, port=args.port, threaded=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/web/hardware_service.py
+++ b/src/web/hardware_service.py
@@ -63,10 +63,19 @@ ERROR_MESSAGES: Dict[str, str] = {
         "the driver's clock table lives."
     ),
     "dma_unavailable": (
-        "Live metrics need the GPU DMA buffer, which has not been located yet. "
-        "Run a DRAM scan in the desktop app to enable metrics, then try again."
+        "This action needs the GPU DMA buffer, which has not been located yet. "
+        "Run a Scan with 'Enable OverDrive & metrics (deep scan)' ticked first, "
+        "then try again."
     ),
     "metrics_failed": "Failed to read the SMU metrics table.",
+    "power_limit_failed": (
+        "The firmware rejected the power-limit change. Try a value closer to "
+        "your card's stock limit. See the server console for details."
+    ),
+    "od_failed": (
+        "The firmware rejected the OverDrive change. The value may be outside "
+        "the range your card accepts. See the server console for details."
+    ),
     "generic": "The requested hardware action could not be completed.",
 }
 
@@ -183,6 +192,7 @@ def _get_vbios_values_or_defaults():
 def run_scan(
     *,
     num_threads: int = 0,
+    deep_scan: bool = False,
     progress: ProgressFn = _noop_progress,
     log: LogFn = _noop_log,
 ) -> Dict[str, Any]:
@@ -190,6 +200,11 @@ def run_scan(
 
     Returns a JSON-serialisable summary and caches it for a later Apply.
     Raises :class:`HardwareUnavailable` on any hardware/engine failure.
+
+    When *deep_scan* is true the (slower) DMA-buffer discovery runs as well,
+    which unlocks the OverDrive controls (GFX clock offset, OD PPT) and live
+    metrics for the rest of the session.  The discovered offset is cached in
+    memory so later OverDrive applies reuse it without re-scanning.
     """
     engine = _import_engine()
 
@@ -199,7 +214,10 @@ def run_scan(
         hw = None
         try:
             try:
-                hw = engine.init_hardware(skip_dma_discovery=True)
+                hw = engine.init_hardware(
+                    skip_dma_discovery=not deep_scan,
+                    gui_log=(log if deep_scan else None),
+                )
             except Exception as exc:  # noqa: BLE001
                 _log.warning("init_hardware failed: %s", exc)
                 raise HardwareUnavailable(
@@ -369,6 +387,225 @@ def apply_boost_clock(
                 "skipped_count": skipped,
                 "message": msg,
             }
+        finally:
+            if hw:
+                try:
+                    engine.cleanup_hardware(hw)
+                except Exception:  # noqa: BLE001
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# Power limit (SMU SetPptLimit -- works without the DMA buffer)
+# ---------------------------------------------------------------------------
+
+# Conservative absolute clamp for the power-limit control.  This is a guard
+# rail, not a recommendation: stay close to your card's stock limit and only
+# nudge it up a little (see the Performance-tab help).
+POWER_LIMIT_MIN_W = 100
+POWER_LIMIT_MAX_W = 400
+
+
+def set_power_limit(
+    watts: int,
+    *,
+    progress: ProgressFn = _noop_progress,
+    log: LogFn = _noop_log,
+) -> Dict[str, Any]:
+    """Set the GPU package-power (PPT) limit in watts via the SMU mailbox.
+
+    This is the single knob that reliably sticks on RDNA4: it sends
+    ``SetPptLimit`` directly to the firmware and does **not** need the DMA
+    buffer, so it works straight after launch without a deep scan.
+    """
+    engine = _import_engine()
+    try:
+        watts = int(watts)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Power limit must be a whole number of watts.") from exc
+    if not (POWER_LIMIT_MIN_W <= watts <= POWER_LIMIT_MAX_W):
+        raise ValueError(
+            f"Power limit must be between {POWER_LIMIT_MIN_W} and "
+            f"{POWER_LIMIT_MAX_W} W."
+        )
+
+    with _hw_lock:
+        hw = None
+        try:
+            try:
+                hw = engine.init_hardware(skip_dma_discovery=True)
+            except Exception as exc:  # noqa: BLE001
+                _log.warning("init_hardware failed: %s", exc)
+                raise HardwareUnavailable(
+                    ERROR_MESSAGES["init_failed"], code="init_failed"
+                ) from exc
+
+            smu = hw["smu"]
+            progress(20, f"Reading current power limit…")
+            try:
+                before = smu.get_ppt_limit()
+            except Exception:  # noqa: BLE001 - read-back is best-effort
+                before = None
+
+            progress(50, f"Setting power limit to {watts} W…")
+            try:
+                smu.set_ppt_limit(watts)
+            except Exception as exc:  # noqa: BLE001
+                _log.warning("set_ppt_limit failed: %s", exc)
+                raise HardwareUnavailable(
+                    ERROR_MESSAGES["power_limit_failed"],
+                    code="power_limit_failed",
+                ) from exc
+
+            try:
+                after = smu.get_ppt_limit()
+            except Exception:  # noqa: BLE001
+                after = None
+
+            progress(100, "Power limit applied.")
+            msg = f"Power limit set to {watts} W"
+            if after is not None:
+                msg += f" (firmware now reports {after} W)"
+            msg += "."
+            log(msg)
+            return {
+                "ok": True,
+                "requested_w": watts,
+                "before_w": before,
+                "after_w": after,
+                "message": msg,
+            }
+        finally:
+            if hw:
+                try:
+                    engine.cleanup_hardware(hw)
+                except Exception:  # noqa: BLE001
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# OverDrive controls (GFX clock offset, OD PPT %) -- need the DMA buffer,
+# i.e. a prior deep scan in this process so the offset is cached.
+# ---------------------------------------------------------------------------
+
+def _require_dma(engine):
+    """init_hardware reusing a cached DMA offset; raise if none is available."""
+    hw = engine.init_hardware(skip_dma_discovery=True)
+    if hw.get("virt") is None:
+        try:
+            engine.cleanup_hardware(hw)
+        except Exception:  # noqa: BLE001
+            pass
+        raise HardwareUnavailable(
+            ERROR_MESSAGES["dma_unavailable"], code="dma_unavailable"
+        )
+    return hw
+
+
+def apply_gfx_offset(
+    offset_mhz: int,
+    *,
+    progress: ProgressFn = _noop_progress,
+    log: LogFn = _noop_log,
+) -> Dict[str, Any]:
+    """Apply a GFX clock frequency offset (MHz) through the OverDrive table.
+
+    Requires a prior deep scan (so the DMA buffer offset is cached).
+    """
+    engine = _import_engine()
+    try:
+        offset_mhz = int(offset_mhz)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("GFX offset must be a whole number of MHz.") from exc
+    if not (-1000 <= offset_mhz <= 1000):
+        raise ValueError("GFX offset must be between -1000 and +1000 MHz.")
+
+    with _hw_lock:
+        hw = None
+        try:
+            try:
+                hw = _require_dma(engine)
+            except HardwareUnavailable:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                _log.warning("init_hardware failed: %s", exc)
+                raise HardwareUnavailable(
+                    ERROR_MESSAGES["init_failed"], code="init_failed"
+                ) from exc
+
+            progress(40, f"Applying GFX offset {offset_mhz:+d} MHz…")
+
+            def _modify(od):
+                od.FeatureCtrlMask |= (1 << engine.PP_OD_FEATURE_GFXCLK_BIT)
+                od.GfxclkFoffset = offset_mhz
+
+            ok, err = engine.apply_od_single_field(hw["smu"], hw["virt"], _modify)
+            if not ok:
+                _log.warning("apply GFX offset failed: %s", err)
+                raise HardwareUnavailable(
+                    ERROR_MESSAGES["od_failed"], code="od_failed"
+                )
+            progress(100, "GFX offset applied.")
+            msg = f"GFX clock offset set to {offset_mhz:+d} MHz."
+            log(msg)
+            return {"ok": True, "offset_mhz": offset_mhz, "message": msg}
+        finally:
+            if hw:
+                try:
+                    engine.cleanup_hardware(hw)
+                except Exception:  # noqa: BLE001
+                    pass
+
+
+def apply_od_ppt(
+    pct: int,
+    *,
+    progress: ProgressFn = _noop_progress,
+    log: LogFn = _noop_log,
+) -> Dict[str, Any]:
+    """Apply an OverDrive PPT percentage (power-limit % over default).
+
+    Requires a prior deep scan (DMA buffer cached).  This is the OverDrive-table
+    equivalent of the absolute :func:`set_power_limit` knob; prefer the absolute
+    watt control unless you specifically want a percentage offset.
+    """
+    engine = _import_engine()
+    try:
+        pct = int(pct)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("OD PPT must be a whole-number percentage.") from exc
+    if not (-30 <= pct <= 30):
+        raise ValueError("OD PPT must be between -30% and +30%.")
+
+    with _hw_lock:
+        hw = None
+        try:
+            try:
+                hw = _require_dma(engine)
+            except HardwareUnavailable:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                _log.warning("init_hardware failed: %s", exc)
+                raise HardwareUnavailable(
+                    ERROR_MESSAGES["init_failed"], code="init_failed"
+                ) from exc
+
+            progress(40, f"Applying OD PPT {pct:+d}%…")
+
+            def _modify(od):
+                od.FeatureCtrlMask |= (1 << engine.PP_OD_FEATURE_PPT_BIT)
+                od.Ppt = pct
+
+            ok, err = engine.apply_od_single_field(hw["smu"], hw["virt"], _modify)
+            if not ok:
+                _log.warning("apply OD PPT failed: %s", err)
+                raise HardwareUnavailable(
+                    ERROR_MESSAGES["od_failed"], code="od_failed"
+                )
+            progress(100, "OD PPT applied.")
+            msg = f"OverDrive PPT set to {pct:+d}% over default."
+            log(msg)
+            return {"ok": True, "pct": pct, "message": msg}
         finally:
             if hw:
                 try:

--- a/src/web/hardware_service.py
+++ b/src/web/hardware_service.py
@@ -797,11 +797,18 @@ def _flatten_pp_tree(node, prefix, baseclock_off, out):
             except (TypeError, ValueError):
                 raw_off = -1
             if raw_off >= 0:
+                tcode = str(node.get("type", "H"))
+                from src.web import pp_help
+                info = pp_help.describe(prefix, tcode)
                 out.append({
                     "path": prefix,
                     "offset": raw_off - baseclock_off,
-                    "type": str(node.get("type", "H")),
+                    "type": tcode,
                     "vbios_value": node.get("value"),
+                    "description": info["description"],
+                    "input_hint": info["input_hint"],
+                    "editable": info["editable"],
+                    "type_label": info["type_label"],
                 })
             return
         for k, child in node.items():

--- a/src/web/hardware_service.py
+++ b/src/web/hardware_service.py
@@ -76,6 +76,14 @@ ERROR_MESSAGES: Dict[str, str] = {
         "The firmware rejected the OverDrive change. The value may be outside "
         "the range your card accepts. See the server console for details."
     ),
+    "pp_failed": (
+        "Could not patch the PowerPlay-table field in memory. Re-run a Scan and "
+        "try again. See the server console for details."
+    ),
+    "escape_failed": (
+        "The D3DKMTEscape OD8 write was rejected by the driver. See the server "
+        "console for details."
+    ),
     "generic": "The requested hardware action could not be completed.",
 }
 
@@ -612,6 +620,500 @@ def apply_od_ppt(
                     engine.cleanup_hardware(hw)
                 except Exception:  # noqa: BLE001
                     pass
+
+
+# ---------------------------------------------------------------------------
+# OverDrive table -- full per-field editor (mirrors src/app/tab_od.py)
+# ---------------------------------------------------------------------------
+
+# Each scalar field: (key/attr, group, unit, feature-bit constant name, label).
+# Array fields are expanded per-index at runtime.  Bit names are resolved against
+# src.engine.od_table so we don't hard-code their numeric values here.
+_OD_SCALAR_FIELDS = [
+    ("GfxclkFoffset", "Frequency", "MHz", "PP_OD_FEATURE_GFXCLK_BIT", "GFX clock offset"),
+    ("UclkFmin", "Frequency", "MHz", "PP_OD_FEATURE_UCLK_BIT", "Memory (UCLK) min"),
+    ("UclkFmax", "Frequency", "MHz", "PP_OD_FEATURE_UCLK_BIT", "Memory (UCLK) max"),
+    ("FclkFmin", "Frequency", "MHz", "PP_OD_FEATURE_FCLK_BIT", "Fabric (FCLK) min"),
+    ("FclkFmax", "Frequency", "MHz", "PP_OD_FEATURE_FCLK_BIT", "Fabric (FCLK) max"),
+    ("Ppt", "Power", "%", "PP_OD_FEATURE_PPT_BIT", "Power limit (PPT) %"),
+    ("Tdc", "Power", "%", "PP_OD_FEATURE_TDC_BIT", "Current limit (TDC) %"),
+    ("GfxEdc", "Power", "", "PP_OD_FEATURE_EDC_BIT", "GFX EDC"),
+    ("GfxPccLimitControl", "Power", "", "PP_OD_FEATURE_EDC_BIT", "GFX PCC limit"),
+    ("VddGfxVmax", "Voltage", "mV", "PP_OD_FEATURE_GFX_VMAX_BIT", "VddGfx Vmax"),
+    ("VddSocVmax", "Voltage", "mV", "PP_OD_FEATURE_SOC_VMAX_BIT", "VddSoc Vmax"),
+    ("GfxclkFmaxVmax", "Voltage", "MHz", "PP_OD_FEATURE_GFX_VMAX_BIT", "GFX clock Fmax@Vmax"),
+    ("MaxOpTemp", "Limits", "C", "PP_OD_FEATURE_TEMPERATURE_BIT", "Max operating temp"),
+    ("FanTargetTemperature", "Fan", "C", "PP_OD_FEATURE_FAN_CURVE_BIT", "Fan target temp"),
+    ("FanMinimumPwm", "Fan", "", "PP_OD_FEATURE_FAN_CURVE_BIT", "Fan minimum PWM"),
+    ("AcousticTargetRpmThreshold", "Fan", "RPM", "PP_OD_FEATURE_FAN_CURVE_BIT", "Acoustic target RPM"),
+    ("AcousticLimitRpmThreshold", "Fan", "RPM", "PP_OD_FEATURE_FAN_CURVE_BIT", "Acoustic limit RPM"),
+    ("FanMode", "Fan", "", "PP_OD_FEATURE_FAN_CURVE_BIT", "Fan mode (0=auto)"),
+    ("FanZeroRpmEnable", "Fan", "", "PP_OD_FEATURE_ZERO_FAN_BIT", "Fan zero-RPM enable"),
+    ("FanZeroRpmStopTemp", "Fan", "C", "PP_OD_FEATURE_ZERO_FAN_BIT", "Fan zero-RPM stop temp"),
+]
+
+# Array fields: (attr, group, unit, bit-name, label-prefix, count-constant-name).
+_OD_ARRAY_FIELDS = [
+    ("VoltageOffsetPerZoneBoundary", "Voltage", "mV", "PP_OD_FEATURE_GFX_VF_CURVE_BIT",
+     "V/F zone", "PP_NUM_OD_VF_CURVE_POINTS"),
+    ("FanLinearPwmPoints", "Fan", "", "PP_OD_FEATURE_FAN_CURVE_BIT",
+     "Fan PWM point", "NUM_OD_FAN_MAX_POINTS"),
+    ("FanLinearTempPoints", "Fan", "C", "PP_OD_FEATURE_FAN_CURVE_BIT",
+     "Fan temp point", "NUM_OD_FAN_MAX_POINTS"),
+]
+
+
+def _od_specs(od_table):
+    """Build the full OD field spec list, expanding arrays per index."""
+    specs = []
+    for attr, group, unit, bit, label in _OD_SCALAR_FIELDS:
+        if hasattr(od_table.OverDriveTable_t, attr):
+            specs.append({"key": attr, "attr": attr, "index": None, "group": group,
+                          "unit": unit, "bit": bit, "label": label})
+    for attr, group, unit, bit, prefix, count_name in _OD_ARRAY_FIELDS:
+        count = getattr(od_table, count_name, 0)
+        for i in range(count):
+            specs.append({"key": f"{attr}_{i}", "attr": attr, "index": i, "group": group,
+                          "unit": unit, "bit": bit, "label": f"{prefix} {i}"})
+    return specs
+
+
+def od_field_layout() -> List[Dict[str, Any]]:
+    """Return the OD field spec (no hardware needed) for the UI to render."""
+    try:
+        from src.engine import od_table
+    except Exception:  # noqa: BLE001
+        return []
+    return [
+        {"key": s["key"], "label": s["label"], "unit": s["unit"], "group": s["group"]}
+        for s in _od_specs(od_table)
+    ]
+
+
+def read_od_fields() -> Dict[str, Any]:
+    """Read the live OverDrive table and return current values per field."""
+    engine = _import_engine()
+    from src.engine import od_table
+    with _hw_lock:
+        hw = None
+        try:
+            try:
+                hw = _require_dma(engine)
+            except HardwareUnavailable:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                _log.warning("init_hardware failed: %s", exc)
+                raise HardwareUnavailable(
+                    ERROR_MESSAGES["init_failed"], code="init_failed"
+                ) from exc
+            od = engine.read_od(hw["smu"], hw["virt"])
+            if od is None:
+                raise HardwareUnavailable(ERROR_MESSAGES["od_failed"], code="od_failed")
+            values = {}
+            for s in _od_specs(od_table):
+                try:
+                    if s["index"] is None:
+                        values[s["key"]] = int(getattr(od, s["attr"]))
+                    else:
+                        values[s["key"]] = int(getattr(od, s["attr"])[s["index"]])
+                except Exception:  # noqa: BLE001
+                    values[s["key"]] = None
+            return {"ok": True, "values": values}
+        finally:
+            if hw:
+                try:
+                    engine.cleanup_hardware(hw)
+                except Exception:  # noqa: BLE001
+                    pass
+
+
+def apply_od_field(
+    key: str,
+    value: int,
+    *,
+    progress: ProgressFn = _noop_progress,
+    log: LogFn = _noop_log,
+) -> Dict[str, Any]:
+    """Set a single OverDrive table field by key. Requires a deep scan."""
+    engine = _import_engine()
+    from src.engine import od_table
+    spec = next((s for s in _od_specs(od_table) if s["key"] == key), None)
+    if spec is None:
+        raise ValueError("Unknown OD field.")
+    try:
+        value = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("OD value must be a whole number.") from exc
+    bit = getattr(od_table, spec["bit"])
+
+    with _hw_lock:
+        hw = None
+        try:
+            try:
+                hw = _require_dma(engine)
+            except HardwareUnavailable:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                _log.warning("init_hardware failed: %s", exc)
+                raise HardwareUnavailable(
+                    ERROR_MESSAGES["init_failed"], code="init_failed"
+                ) from exc
+
+            progress(40, f"Setting {spec['label']} = {value}…")
+
+            def _modify(od):
+                od.FeatureCtrlMask |= (1 << bit)
+                if spec["index"] is None:
+                    setattr(od, spec["attr"], value)
+                else:
+                    getattr(od, spec["attr"])[spec["index"]] = value
+
+            ok, err = engine.apply_od_single_field(hw["smu"], hw["virt"], _modify)
+            if not ok:
+                _log.warning("apply OD field %s failed: %s", key, err)
+                raise HardwareUnavailable(ERROR_MESSAGES["od_failed"], code="od_failed")
+            progress(100, "Applied.")
+            msg = f"OverDrive: {spec['label']} set to {value}{(' ' + spec['unit']) if spec['unit'] else ''}."
+            log(msg)
+            return {"ok": True, "key": key, "value": value, "message": msg}
+        finally:
+            if hw:
+                try:
+                    engine.cleanup_hardware(hw)
+                except Exception:  # noqa: BLE001
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# PowerPlay table -- full field editor (mirrors src/app/tab_pp.py)
+# ---------------------------------------------------------------------------
+
+def _flatten_pp_tree(node, prefix, baseclock_off, out):
+    """Walk the decoded PP tree, collecting editable leaves (value+offset)."""
+    if isinstance(node, dict):
+        if "value" in node and "offset" in node:
+            try:
+                raw_off = int(node.get("offset", -1))
+            except (TypeError, ValueError):
+                raw_off = -1
+            if raw_off >= 0:
+                out.append({
+                    "path": prefix,
+                    "offset": raw_off - baseclock_off,
+                    "type": str(node.get("type", "H")),
+                    "vbios_value": node.get("value"),
+                })
+            return
+        for k, child in node.items():
+            child_path = f"{prefix}.{k}" if prefix else str(k)
+            _flatten_pp_tree(child, child_path, baseclock_off, out)
+    elif isinstance(node, (list, tuple)):
+        for i, child in enumerate(node):
+            _flatten_pp_tree(child, f"{prefix}[{i}]", baseclock_off, out)
+
+
+def pp_field_layout() -> Dict[str, Any]:
+    """Decode the VBIOS PP table into a flat, editable field list."""
+    try:
+        from src.app.constants import DEFAULT_VBIOS_PATH
+        from src.io.vbios_storage import read_vbios_decoded
+        from src.io.vbios_parser import decode_pp_table_full
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("PP decode imports failed: %s", exc)
+        return {"available": False, "reason": "PP decoding is unavailable.", "fields": []}
+
+    rom_bytes, _ = read_vbios_decoded(DEFAULT_VBIOS_PATH)
+    if not rom_bytes:
+        return {
+            "available": False,
+            "reason": "A VBIOS ROM (bios/vbios.rom) is required to edit PP-table fields.",
+            "fields": [],
+        }
+    decoded = decode_pp_table_full(rom_bytes, rom_path=DEFAULT_VBIOS_PATH)
+    if decoded is None or getattr(decoded, "data", None) is None:
+        return {"available": False, "reason": "Could not decode the PP table.", "fields": []}
+
+    vbios = _get_vbios_values_or_defaults_quiet()
+    baseclock_off = int(getattr(vbios, "baseclock_pp_offset", 0) or 0) if vbios else 0
+    fields: List[Dict[str, Any]] = []
+    _flatten_pp_tree(decoded.data, "", baseclock_off, fields)
+    return {"available": True, "fields": fields}
+
+
+def _get_vbios_values_or_defaults_quiet():
+    try:
+        return _get_vbios_values_or_defaults()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def apply_pp_field(
+    offset: int,
+    value,
+    type_code: str = "H",
+    *,
+    progress: ProgressFn = _noop_progress,
+    log: LogFn = _noop_log,
+) -> Dict[str, Any]:
+    """Patch a single PP-table field across all scanned RAM copies.
+
+    Requires a prior successful scan (the volatile RAM PP-table addresses).
+    """
+    engine = _import_engine()
+    scan_result = _get_cached_result()
+    if not (scan_result and getattr(scan_result, "valid_addrs", None)):
+        raise HardwareUnavailable(ERROR_MESSAGES["no_scan"], code="no_scan")
+
+    with _hw_lock:
+        hw = None
+        try:
+            try:
+                hw = engine.init_hardware(skip_dma_discovery=True)
+            except Exception as exc:  # noqa: BLE001
+                _log.warning("init_hardware failed: %s", exc)
+                raise HardwareUnavailable(
+                    ERROR_MESSAGES["init_failed"], code="init_failed"
+                ) from exc
+            progress(40, f"Patching PP field @0x{int(offset):X}…")
+            res = engine.patch_pp_single_field(
+                hw["inpout"], scan_result, int(offset), value, str(type_code)
+            )
+            if not res.get("ok"):
+                raise HardwareUnavailable(ERROR_MESSAGES["pp_failed"], code="pp_failed")
+            progress(100, "Patched.")
+            msg = (
+                f"PP field @0x{int(offset):X} set to {value} "
+                f"({res.get('writes', 0)}/{res.get('addrs', 0)} copies)."
+            )
+            log(msg)
+            return {"ok": True, "offset": int(offset), "value": value,
+                    "writes": res.get("writes", 0), "message": msg}
+        finally:
+            if hw:
+                try:
+                    engine.cleanup_hardware(hw)
+                except Exception:  # noqa: BLE001
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# SMU controls -- GFX clock limits, power-saving lock (all DMA-free)
+# ---------------------------------------------------------------------------
+
+def apply_freq_limits(
+    gfx_min: int = 0,
+    gfx_max: int = 0,
+    *,
+    progress: ProgressFn = _noop_progress,
+    log: LogFn = _noop_log,
+) -> Dict[str, Any]:
+    """Set the GFX clock soft/hard min and/or max (MHz) via the SMU. DMA-free."""
+    engine = _import_engine()
+    gfx_min = int(gfx_min or 0)
+    gfx_max = int(gfx_max or 0)
+    if gfx_min and not (200 <= gfx_min <= 4000):
+        raise ValueError("GFX min must be between 200 and 4000 MHz.")
+    if gfx_max and not (200 <= gfx_max <= 4000):
+        raise ValueError("GFX max must be between 200 and 4000 MHz.")
+    if gfx_min and gfx_max and gfx_min > gfx_max:
+        raise ValueError("GFX min cannot exceed GFX max.")
+
+    with _hw_lock:
+        hw = None
+        try:
+            try:
+                hw = engine.init_hardware(skip_dma_discovery=True)
+            except Exception as exc:  # noqa: BLE001
+                _log.warning("init_hardware failed: %s", exc)
+                raise HardwareUnavailable(
+                    ERROR_MESSAGES["init_failed"], code="init_failed"
+                ) from exc
+            smu = hw["smu"]
+            gfx = engine.PPCLK.GFXCLK & 0xFFFF
+            done = []
+            if gfx_max:
+                p = (gfx << 16) | (gfx_max & 0xFFFF)
+                smu.send_msg(engine.PPSMC.SetSoftMaxByFreq, p)
+                smu.send_msg(engine.PPSMC.SetHardMaxByFreq, p)
+                done.append(f"max={gfx_max} MHz")
+            if gfx_min:
+                p = (gfx << 16) | (gfx_min & 0xFFFF)
+                smu.send_msg(engine.PPSMC.SetSoftMinByFreq, p)
+                smu.send_msg(engine.PPSMC.SetHardMinByFreq, p)
+                done.append(f"min={gfx_min} MHz")
+            if not done:
+                return {"ok": True, "message": "No GFX clock limits changed."}
+            progress(100, "Applied.")
+            msg = "GFX clock limits set: " + ", ".join(done) + "."
+            log(msg)
+            return {"ok": True, "gfx_min": gfx_min, "gfx_max": gfx_max, "message": msg}
+        finally:
+            if hw:
+                try:
+                    engine.cleanup_hardware(hw)
+                except Exception:  # noqa: BLE001
+                    pass
+
+
+def apply_power_saving_lock(
+    lock: bool = True,
+    *,
+    progress: ProgressFn = _noop_progress,
+    log: LogFn = _noop_log,
+) -> Dict[str, Any]:
+    """Disable (lock) or re-allow the GFX power-saving features that cause
+    clock-gating/idle downclock (DS_GFXCLK, GFX_ULV, GFXOFF). DMA-free."""
+    engine = _import_engine()
+    with _hw_lock:
+        hw = None
+        try:
+            try:
+                hw = engine.init_hardware(skip_dma_discovery=True)
+            except Exception as exc:  # noqa: BLE001
+                _log.warning("init_hardware failed: %s", exc)
+                raise HardwareUnavailable(
+                    ERROR_MESSAGES["init_failed"], code="init_failed"
+                ) from exc
+            smu = hw["smu"]
+            feat_mask = ((1 << engine.SMU_FEATURE.DS_GFXCLK) |
+                         (1 << engine.SMU_FEATURE.GFX_ULV) |
+                         (1 << engine.SMU_FEATURE.GFXOFF))
+            if lock:
+                smu.send_msg(engine.PPSMC.DisallowGfxOff)
+                smu.send_msg(engine.PPSMC.DisableSmuFeaturesLow, feat_mask)
+                msg = "Power-saving features locked (DS_GFXCLK / GFX_ULV / GFXOFF disabled)."
+            else:
+                smu.send_msg(engine.PPSMC.EnableSmuFeaturesLow, feat_mask)
+                smu.send_msg(engine.PPSMC.AllowGfxOff)
+                msg = "Power-saving features re-enabled (back to stock idle behaviour)."
+            progress(100, "Applied.")
+            log(msg)
+            return {"ok": True, "locked": bool(lock), "message": msg}
+        finally:
+            if hw:
+                try:
+                    engine.cleanup_hardware(hw)
+                except Exception:  # noqa: BLE001
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# D3DKMTEscape OD8 path (no admin) -- mirrors src/app/tab_escape.py
+# ---------------------------------------------------------------------------
+
+def apply_escape(
+    clock_mhz: int = 0,
+    power_w: int = 0,
+    gfx_offset_mhz: int = 0,
+    *,
+    progress: ProgressFn = _noop_progress,
+    log: LogFn = _noop_log,
+) -> Dict[str, Any]:
+    """Apply OD settings through the D3DKMTEscape path (no admin required).
+
+    Only the high-level knobs that map cleanly to OD8 entries are exposed
+    (clock ceiling, power limit, GFX offset); fields left at 0 are unchanged.
+    """
+    engine = _import_engine()
+    clock_mhz = int(clock_mhz or 0)
+    power_w = int(power_w or 0)
+    gfx_offset_mhz = int(gfx_offset_mhz or 0)
+    if not (clock_mhz or power_w or gfx_offset_mhz):
+        raise ValueError("Set at least one of clock, power, or GFX offset.")
+
+    settings = engine.OverclockSettings(
+        clock=clock_mhz or 0,
+        power=power_w or 0,
+        offset=gfx_offset_mhz or 0,
+        od_ppt=0,
+        od_tdc=0,
+    )
+    progress(40, "Sending OD8 settings via D3DKMTEscape…")
+    result = engine.apply_od_via_escape(settings)
+    if not result.get("ok"):
+        _log.warning("escape apply failed: %s", result.get("error"))
+        raise HardwareUnavailable(ERROR_MESSAGES["escape_failed"], code="escape_failed")
+    progress(100, "Applied.")
+    changed = result.get("changed_indices", [])
+    msg = f"Escape OD8 applied ({len(changed)} value(s) changed)."
+    log(msg)
+    return {
+        "ok": True,
+        "changed_indices": list(changed),
+        "verified": _jsonable(result.get("verified", {}) or {}),
+        "message": msg,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Profile apply -- orchestrates the volatile sections in dependency order
+# ---------------------------------------------------------------------------
+
+def apply_profile(
+    settings: Dict[str, Any],
+    *,
+    progress: ProgressFn = _noop_progress,
+    log: LogFn = _noop_log,
+) -> Dict[str, Any]:
+    """Apply a saved profile's volatile sections in a safe order.
+
+    Reuses the public single-action functions (each manages its own hardware
+    handle + lock), so this never holds the hardware lock itself.  Registry
+    settings are never part of a profile, so nothing here is persistent.
+    """
+    settings = settings or {}
+    needs_dma = any(k in settings for k in ("gfx_offset_mhz", "od_ppt_pct", "od_fields"))
+    needs_scan = needs_dma or any(k in settings for k in ("boost_clock_mhz", "pp_fields"))
+
+    results: List[Dict[str, Any]] = []
+
+    def _step(name, fn):
+        try:
+            r = fn()
+            results.append({"step": name, "ok": True, "message": r.get("message", "done")})
+            log(f"[{name}] {r.get('message', 'done')}")
+        except Exception as exc:  # noqa: BLE001 - per-step, keep going
+            detail = safe_message(exc) if isinstance(exc, HardwareUnavailable) else str(exc)
+            results.append({"step": name, "ok": False, "message": detail})
+            log(f"[{name}] FAILED: {detail}")
+
+    # 1) Scan if needed and not already cached.
+    if needs_scan and _get_cached_result() is None:
+        progress(5, "Scanning memory for the profile…")
+        _step("scan", lambda: run_scan(deep_scan=needs_dma, progress=progress, log=log))
+
+    # 2) Apply sections (order: power -> clocks/pp -> OD -> features).
+    if "power_limit_w" in settings:
+        progress(30, "Power limit…")
+        _step("power_limit", lambda: set_power_limit(settings["power_limit_w"], progress=progress, log=log))
+    if "boost_clock_mhz" in settings:
+        progress(45, "Boost clock…")
+        _step("boost_clock", lambda: apply_boost_clock(settings["boost_clock_mhz"], progress=progress, log=log))
+    for off, spec in (settings.get("pp_fields") or {}).items():
+        _step(f"pp@{off}", lambda off=off, spec=spec: apply_pp_field(
+            int(off), spec.get("value"), spec.get("type", "H"), progress=progress, log=log))
+    if "gfx_offset_mhz" in settings:
+        progress(65, "GFX offset…")
+        _step("gfx_offset", lambda: apply_gfx_offset(settings["gfx_offset_mhz"], progress=progress, log=log))
+    if "od_ppt_pct" in settings:
+        progress(75, "OD PPT…")
+        _step("od_ppt", lambda: apply_od_ppt(settings["od_ppt_pct"], progress=progress, log=log))
+    for key, val in (settings.get("od_fields") or {}).items():
+        _step(f"od.{key}", lambda key=key, val=val: apply_od_field(key, val, progress=progress, log=log))
+    fl = settings.get("freq_limits") or {}
+    if fl.get("gfx_min") or fl.get("gfx_max"):
+        progress(85, "GFX clock limits…")
+        _step("freq_limits", lambda: apply_freq_limits(
+            fl.get("gfx_min", 0), fl.get("gfx_max", 0), progress=progress, log=log))
+
+    ok = all(r["ok"] for r in results) if results else False
+    applied = sum(1 for r in results if r["ok"])
+    progress(100, "Profile applied.")
+    return {
+        "ok": ok,
+        "steps": results,
+        "message": f"Profile applied: {applied}/{len(results)} step(s) succeeded.",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/src/web/hardware_service.py
+++ b/src/web/hardware_service.py
@@ -31,7 +31,56 @@ ProgressFn = Callable[[float, str], None]
 
 
 class HardwareUnavailable(RuntimeError):
-    """Raised when the overclock engine / GPU hardware cannot be used."""
+    """Raised when the overclock engine / GPU hardware cannot be used.
+
+    Carries a stable ``code`` identifying the failure category.  The HTTP layer
+    maps that code to a fixed, human-authored message via :func:`safe_message`
+    so that **no exception-derived text is ever returned to the client** (the
+    raw exception detail is only ever written to the server log).
+    """
+
+    def __init__(self, message: str, code: str = "generic"):
+        super().__init__(message)
+        self.code = code
+
+
+# Fixed, human-authored messages keyed by failure code.  These are the only
+# strings sent to the browser for hardware errors; they never contain stack
+# traces or raw exception text.
+ERROR_MESSAGES: Dict[str, str] = {
+    "engine_unavailable": (
+        "The overclock engine is unavailable on this system. Hardware actions "
+        "require Windows with the AMD driver, the bundled kernel drivers, and "
+        "Administrator privileges. See the server console for details."
+    ),
+    "init_failed": (
+        "Could not initialise the GPU drivers. Make sure the AMD driver and "
+        "bundled kernel drivers are installed and that the server is running "
+        "as Administrator. See the server console for details."
+    ),
+    "no_scan": (
+        "No scan result available. Run a Scan first so Adrenalift knows where "
+        "the driver's clock table lives."
+    ),
+    "dma_unavailable": (
+        "Live metrics need the GPU DMA buffer, which has not been located yet. "
+        "Run a DRAM scan in the desktop app to enable metrics, then try again."
+    ),
+    "metrics_failed": "Failed to read the SMU metrics table.",
+    "generic": "The requested hardware action could not be completed.",
+}
+
+
+def safe_message(exc: "HardwareUnavailable") -> str:
+    """Return a fixed, safe-to-display message for a hardware error.
+
+    The returned value is a controlled literal selected by the exception's
+    ``code``; it is never derived from the underlying exception text.
+    """
+    code = getattr(exc, "code", "generic")
+    if code in ERROR_MESSAGES:
+        return ERROR_MESSAGES[code]
+    return ERROR_MESSAGES["generic"]
 
 
 # Serialise all hardware access: the underlying drivers and SMU mailbox are a
@@ -65,10 +114,7 @@ def _import_engine():
         # (avoids leaking internal stack-trace information over HTTP).
         _log.warning("Overclock engine import failed: %s", exc)
         raise HardwareUnavailable(
-            "The overclock engine is unavailable on this system "
-            f"({platform.system()}). Hardware actions require Windows with the "
-            "AMD driver, the bundled kernel drivers, and Administrator "
-            "privileges. See the server console for details."
+            ERROR_MESSAGES["engine_unavailable"], code="engine_unavailable"
         ) from exc
     return engine
 
@@ -83,8 +129,9 @@ def engine_status() -> Dict[str, Any]:
     try:
         _import_engine()
         info["available"] = True
-    except HardwareUnavailable as exc:
-        info["reason"] = str(exc)
+    except HardwareUnavailable:
+        # Use the fixed message, never the exception text.
+        info["reason"] = ERROR_MESSAGES["engine_unavailable"]
     return info
 
 
@@ -97,12 +144,14 @@ def vbios_summary() -> Dict[str, Any]:
     try:
         from src.app.constants import DEFAULT_VBIOS_PATH, _get_vbios_values
     except Exception as exc:  # noqa: BLE001
-        return {"available": False, "summary": f"VBIOS info unavailable: {exc}"}
+        _log.warning("VBIOS constants import failed: %s", exc)
+        return {"available": False, "summary": "VBIOS information is unavailable."}
 
     try:
         vals = _get_vbios_values(DEFAULT_VBIOS_PATH)
     except Exception as exc:  # noqa: BLE001
-        return {"available": False, "summary": f"VBIOS parse failed: {exc}"}
+        _log.warning("VBIOS parse failed: %s", exc)
+        return {"available": False, "summary": "Could not parse the VBIOS ROM."}
 
     if vals is None:
         return {
@@ -154,10 +203,7 @@ def run_scan(
             except Exception as exc:  # noqa: BLE001
                 _log.warning("init_hardware failed: %s", exc)
                 raise HardwareUnavailable(
-                    "Could not initialise the GPU drivers. Make sure the "
-                    "AMD driver and bundled kernel drivers are installed and "
-                    "that the server is running as Administrator. See the "
-                    "server console for details."
+                    ERROR_MESSAGES["init_failed"], code="init_failed"
                 ) from exc
 
             inpout = hw["inpout"]
@@ -270,10 +316,7 @@ def apply_boost_clock(
     scan_result = _get_cached_result()
     valid = getattr(scan_result, "valid_addrs", None) if scan_result else None
     if not valid:
-        raise HardwareUnavailable(
-            "No scan result available. Run a Scan first so Adrenalift knows "
-            "where the driver's clock table lives."
-        )
+        raise HardwareUnavailable(ERROR_MESSAGES["no_scan"], code="no_scan")
 
     try:
         clock_mhz = int(clock_mhz)
@@ -293,10 +336,7 @@ def apply_boost_clock(
             except Exception as exc:  # noqa: BLE001
                 _log.warning("init_hardware failed: %s", exc)
                 raise HardwareUnavailable(
-                    "Could not initialise the GPU drivers. Make sure the "
-                    "AMD driver and bundled kernel drivers are installed and "
-                    "that the server is running as Administrator. See the "
-                    "server console for details."
+                    ERROR_MESSAGES["init_failed"], code="init_failed"
                 ) from exc
 
             inpout, smu = hw["inpout"], hw["smu"]
@@ -352,10 +392,7 @@ def read_status() -> Dict[str, Any]:
             except Exception as exc:  # noqa: BLE001
                 _log.warning("init_hardware failed: %s", exc)
                 raise HardwareUnavailable(
-                    "Could not initialise the GPU drivers. Make sure the "
-                    "AMD driver and bundled kernel drivers are installed and "
-                    "that the server is running as Administrator. See the "
-                    "server console for details."
+                    ERROR_MESSAGES["init_failed"], code="init_failed"
                 ) from exc
 
             smu = hw["smu"]
@@ -389,21 +426,18 @@ def read_metrics() -> Dict[str, Any]:
             except Exception as exc:  # noqa: BLE001
                 _log.warning("init_hardware failed: %s", exc)
                 raise HardwareUnavailable(
-                    "Could not initialise the GPU drivers. Make sure the "
-                    "AMD driver and bundled kernel drivers are installed and "
-                    "that the server is running as Administrator. See the "
-                    "server console for details."
+                    ERROR_MESSAGES["init_failed"], code="init_failed"
                 ) from exc
 
             if hw.get("virt") is None:
                 raise HardwareUnavailable(
-                    "Live metrics need the GPU DMA buffer, which has not been "
-                    "located yet. Run a DRAM scan in the desktop app to enable "
-                    "metrics, then try again."
+                    ERROR_MESSAGES["dma_unavailable"], code="dma_unavailable"
                 )
             _m, values = engine.read_smu_metrics_full(hw["smu"], hw["virt"])
             if not values:
-                raise HardwareUnavailable("Failed to read SMU metrics table.")
+                raise HardwareUnavailable(
+                    ERROR_MESSAGES["metrics_failed"], code="metrics_failed"
+                )
             return {"ok": True, "metrics": _jsonable(values)}
         finally:
             if hw:

--- a/src/web/hardware_service.py
+++ b/src/web/hardware_service.py
@@ -1,0 +1,402 @@
+"""Platform-agnostic hardware service for the Adrenalift web server.
+
+This module is the bridge between the HTTP layer and
+:mod:`src.engine.overclock_engine`.  It reproduces the behaviour of the desktop
+``ScanThread`` / ``ApplyWorker`` (open hardware, do the work, always clean up)
+but with plain progress/log callbacks instead of Qt signals, and it caches the
+most recent scan result so an Apply can reuse it -- exactly as the desktop
+``MainOverclockWidget`` does.
+
+The overclock engine performs Windows-only operations (physical-memory mapping,
+SMU mailbox).  Importing it therefore fails on other platforms.  Every public
+function here imports the engine lazily and raises :class:`HardwareUnavailable`
+with a clear, user-facing message when it cannot be used, so the web server and
+its UI stay usable everywhere while real hardware actions are gated to a
+properly configured Windows host.
+"""
+
+from __future__ import annotations
+
+import platform
+import threading
+from collections import Counter
+from typing import Any, Callable, Dict, List, Optional
+
+LogFn = Callable[[str], None]
+ProgressFn = Callable[[float, str], None]
+
+
+class HardwareUnavailable(RuntimeError):
+    """Raised when the overclock engine / GPU hardware cannot be used."""
+
+
+# Serialise all hardware access: the underlying drivers and SMU mailbox are a
+# single shared resource and must not be entered concurrently.
+_hw_lock = threading.Lock()
+
+# Cached result of the most recent successful scan (mirrors the desktop
+# ``MainOverclockWidget.scan_result``).  Apply needs the valid addresses.
+_last_scan: Optional[Dict[str, Any]] = None
+_last_scan_lock = threading.Lock()
+
+
+def _noop_log(_msg: str) -> None:
+    pass
+
+
+def _noop_progress(_pct: float, _msg: str = "") -> None:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Engine availability
+# ---------------------------------------------------------------------------
+
+def _import_engine():
+    """Import and return the overclock engine module, or raise a clear error."""
+    try:
+        from src.engine import overclock_engine as engine
+    except Exception as exc:  # noqa: BLE001 - convert to a friendly message
+        raise HardwareUnavailable(
+            "The overclock engine is unavailable on this system "
+            f"({platform.system()}). Hardware actions require Windows with the "
+            "AMD driver, the bundled kernel drivers, and Administrator "
+            f"privileges. Details: {exc}"
+        ) from exc
+    return engine
+
+
+def engine_status() -> Dict[str, Any]:
+    """Return a non-throwing description of engine availability for the UI."""
+    info: Dict[str, Any] = {
+        "platform": platform.system(),
+        "available": False,
+        "reason": "",
+    }
+    try:
+        _import_engine()
+        info["available"] = True
+    except HardwareUnavailable as exc:
+        info["reason"] = str(exc)
+    return info
+
+
+# ---------------------------------------------------------------------------
+# VBIOS summary (read-only, used for the info banner)
+# ---------------------------------------------------------------------------
+
+def vbios_summary() -> Dict[str, Any]:
+    """Return a short description of the detected VBIOS values (or defaults)."""
+    try:
+        from src.app.constants import DEFAULT_VBIOS_PATH, _get_vbios_values
+    except Exception as exc:  # noqa: BLE001
+        return {"available": False, "summary": f"VBIOS info unavailable: {exc}"}
+
+    try:
+        vals = _get_vbios_values(DEFAULT_VBIOS_PATH)
+    except Exception as exc:  # noqa: BLE001
+        return {"available": False, "summary": f"VBIOS parse failed: {exc}"}
+
+    if vals is None:
+        return {
+            "available": False,
+            "summary": "No VBIOS ROM found (bios/vbios.rom). Built-in defaults "
+            "will be used.",
+        }
+    try:
+        summary = vals.summary()
+    except Exception:  # noqa: BLE001
+        summary = "VBIOS detected."
+    return {"available": True, "summary": summary}
+
+
+def _get_vbios_values_or_defaults():
+    from src.app.constants import DEFAULT_VBIOS_PATH, _get_vbios_values
+
+    vbios = _get_vbios_values(DEFAULT_VBIOS_PATH)
+    if vbios is None:
+        engine = _import_engine()
+        vbios = engine.parse_vbios_or_defaults(DEFAULT_VBIOS_PATH)
+    return vbios
+
+
+# ---------------------------------------------------------------------------
+# Scan (mirrors src/app/workers.py ScanThread.run)
+# ---------------------------------------------------------------------------
+
+def run_scan(
+    *,
+    num_threads: int = 0,
+    progress: ProgressFn = _noop_progress,
+    log: LogFn = _noop_log,
+) -> Dict[str, Any]:
+    """Scan physical memory for the driver's PowerPlay table.
+
+    Returns a JSON-serialisable summary and caches it for a later Apply.
+    Raises :class:`HardwareUnavailable` on any hardware/engine failure.
+    """
+    engine = _import_engine()
+
+    with _hw_lock:
+        vbios = _get_vbios_values_or_defaults()
+
+        hw = None
+        try:
+            try:
+                hw = engine.init_hardware(skip_dma_discovery=True)
+            except Exception as exc:  # noqa: BLE001
+                raise HardwareUnavailable(f"Hardware init failed: {exc}") from exc
+
+            inpout = hw["inpout"]
+            dma_ok = hw.get("virt") is not None
+
+            settings = engine.OverclockSettings(
+                game_clock=vbios.gameclock_ac,
+                boost_clock=vbios.boostclock_ac,
+                clock=vbios.gameclock_ac,
+            )
+            scan_opts = engine.ScanOptions()
+            scan_opts.num_threads = num_threads
+
+            if not dma_ok:
+                progress(
+                    2,
+                    "DMA buffer not found \u2014 PP-table patching still works; "
+                    "run a DRAM scan in the desktop app to enable OD/metrics.",
+                )
+
+            result = engine.scan_for_pptable(
+                inpout,
+                settings,
+                scan_opts=scan_opts,
+                progress_callback=progress,
+                vbios_values=vbios,
+            )
+
+            if hw and result and dma_ok:
+                try:
+                    od = engine.read_od(hw["smu"], hw["virt"])
+                    if od is not None:
+                        result.od_table = od
+                except Exception:  # noqa: BLE001 - OD readback is best-effort
+                    pass
+
+            summary = _scan_result_to_dict(result, dma_ok=dma_ok)
+            _store_scan(result, summary)
+            log(summary["message"])
+            return summary
+        finally:
+            if hw:
+                try:
+                    engine.cleanup_hardware(hw)
+                except Exception:  # noqa: BLE001
+                    pass
+
+
+def _scan_result_to_dict(result, *, dma_ok: bool) -> Dict[str, Any]:
+    valid = list(getattr(result, "valid_addrs", []) or [])
+    rejected = list(getattr(result, "rejected_addrs", []) or [])
+    error = getattr(result, "error", None)
+    has_od = getattr(result, "od_table", None) is not None
+
+    if error and not valid:
+        message = f"Scan failed: {error}"
+        ready = has_od
+    elif valid:
+        message = f"Found {len(valid)} PowerPlay table(s) in memory."
+        ready = True
+    else:
+        message = "Scan complete: no PowerPlay table found."
+        ready = has_od
+
+    return {
+        "ok": bool(valid) or has_od,
+        "ready_to_apply": bool(ready),
+        "valid_count": len(valid),
+        "valid_addrs": [f"0x{a:012X}" for a in valid],
+        "rejected_count": len(rejected),
+        "has_od_table": has_od,
+        "dma_available": bool(dma_ok),
+        "error": error,
+        "message": message,
+    }
+
+
+def _store_scan(result, summary: Dict[str, Any]) -> None:
+    global _last_scan
+    with _last_scan_lock:
+        _last_scan = {"result": result, "summary": summary}
+
+
+def last_scan_summary() -> Optional[Dict[str, Any]]:
+    with _last_scan_lock:
+        return dict(_last_scan["summary"]) if _last_scan else None
+
+
+def _get_cached_result():
+    with _last_scan_lock:
+        return _last_scan["result"] if _last_scan else None
+
+
+# ---------------------------------------------------------------------------
+# Apply boost clock (mirrors MainOverclockWidget._on_apply_simple)
+# ---------------------------------------------------------------------------
+
+def apply_boost_clock(
+    clock_mhz: int,
+    *,
+    progress: ProgressFn = _noop_progress,
+    log: LogFn = _noop_log,
+) -> Dict[str, Any]:
+    """Patch the driver's PP table with *clock_mhz* and activate it.
+
+    Requires a prior successful :func:`run_scan` that found valid addresses.
+    """
+    engine = _import_engine()
+
+    scan_result = _get_cached_result()
+    valid = getattr(scan_result, "valid_addrs", None) if scan_result else None
+    if not valid:
+        raise HardwareUnavailable(
+            "No scan result available. Run a Scan first so Adrenalift knows "
+            "where the driver's clock table lives."
+        )
+
+    try:
+        clock_mhz = int(clock_mhz)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Boost clock must be a whole number of MHz.") from exc
+
+    with _hw_lock:
+        vbios = _get_vbios_values_or_defaults()
+        settings = engine.OverclockSettings(
+            clock=clock_mhz, offset=0, od_ppt=0, od_tdc=0
+        )
+
+        hw = None
+        try:
+            try:
+                hw = engine.init_hardware(skip_dma_discovery=True)
+            except Exception as exc:  # noqa: BLE001
+                raise HardwareUnavailable(f"Hardware init failed: {exc}") from exc
+
+            inpout, smu = hw["inpout"], hw["smu"]
+            results = engine.apply_clocks_only(
+                inpout,
+                smu,
+                scan_result,
+                settings,
+                vbios_values=vbios,
+                progress_callback=lambda pct, msg: (progress(pct, msg), log(msg)),
+            )
+            patched = results.get("patched_count", 0)
+            skipped = results.get("skipped_count", 0)
+            msg = (
+                f"Applied {clock_mhz} MHz boost clock: {patched} patched, "
+                f"{skipped} skipped."
+            )
+            log(msg)
+            if hw.get("virt") is None:
+                log(
+                    "Note: DMA buffer not available \u2014 OD/metrics read-back "
+                    "skipped (this does not affect the clock patch)."
+                )
+            return {
+                "ok": True,
+                "clock_mhz": clock_mhz,
+                "patched_count": patched,
+                "skipped_count": skipped,
+                "message": msg,
+            }
+        finally:
+            if hw:
+                try:
+                    engine.cleanup_hardware(hw)
+                except Exception:  # noqa: BLE001
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# Read-only status / metrics
+# ---------------------------------------------------------------------------
+
+def read_status() -> Dict[str, Any]:
+    """Return SMU state + DPM ranges for display (read-only)."""
+    engine = _import_engine()
+    with _hw_lock:
+        hw = None
+        try:
+            try:
+                hw = engine.init_hardware(skip_dma_discovery=True)
+            except Exception as exc:  # noqa: BLE001
+                raise HardwareUnavailable(f"Hardware init failed: {exc}") from exc
+
+            smu = hw["smu"]
+            state = engine.query_smu_state(smu)
+            dpm = engine.get_dpm_ranges(smu)
+            return {
+                "ok": True,
+                "smu_version": state.get("smu_version"),
+                "smu_drv_if": state.get("smu_drv_if"),
+                "ppt_limit": state.get("smu_ppt"),
+                "voltage": state.get("smu_voltage"),
+                "dpm_ranges": dpm,
+                "dma_available": hw.get("virt") is not None,
+            }
+        finally:
+            if hw:
+                try:
+                    engine.cleanup_hardware(hw)
+                except Exception:  # noqa: BLE001
+                    pass
+
+
+def read_metrics() -> Dict[str, Any]:
+    """Return the flattened live SMU metrics dict (read-only)."""
+    engine = _import_engine()
+    with _hw_lock:
+        hw = None
+        try:
+            try:
+                hw = engine.init_hardware(skip_dma_discovery=True)
+            except Exception as exc:  # noqa: BLE001
+                raise HardwareUnavailable(f"Hardware init failed: {exc}") from exc
+
+            if hw.get("virt") is None:
+                raise HardwareUnavailable(
+                    "Live metrics need the GPU DMA buffer, which has not been "
+                    "located yet. Run a DRAM scan in the desktop app to enable "
+                    "metrics, then try again."
+                )
+            _m, values = engine.read_smu_metrics_full(hw["smu"], hw["virt"])
+            if not values:
+                raise HardwareUnavailable("Failed to read SMU metrics table.")
+            return {"ok": True, "metrics": _jsonable(values)}
+        finally:
+            if hw:
+                try:
+                    engine.cleanup_hardware(hw)
+                except Exception:  # noqa: BLE001
+                    pass
+
+
+def _jsonable(values: Dict[str, Any]) -> Dict[str, Any]:
+    """Coerce metric values to JSON-serialisable scalars."""
+    out: Dict[str, Any] = {}
+    for key, val in values.items():
+        if isinstance(val, (int, float, str, bool)) or val is None:
+            out[key] = val
+        elif isinstance(val, (list, tuple)):
+            out[key] = [v if isinstance(v, (int, float, str, bool)) else str(v) for v in val]
+        else:
+            out[key] = str(val)
+    return out
+
+
+def metrics_display_sections() -> List[Dict[str, Any]]:
+    """Return the grouped metric layout used by the desktop app for display."""
+    try:
+        from src.app.constants import _METRICS_DISPLAY_SECTIONS
+    except Exception:  # noqa: BLE001
+        return []
+    return [{"title": title, "keys": list(keys)} for title, keys in _METRICS_DISPLAY_SECTIONS]

--- a/src/web/hardware_service.py
+++ b/src/web/hardware_service.py
@@ -22,6 +22,10 @@ import threading
 from collections import Counter
 from typing import Any, Callable, Dict, List, Optional
 
+import logging
+
+_log = logging.getLogger("adrenalift.web")
+
 LogFn = Callable[[str], None]
 ProgressFn = Callable[[float, str], None]
 
@@ -57,11 +61,14 @@ def _import_engine():
     try:
         from src.engine import overclock_engine as engine
     except Exception as exc:  # noqa: BLE001 - convert to a friendly message
+        # Log the raw detail server-side only; never return it to the client
+        # (avoids leaking internal stack-trace information over HTTP).
+        _log.warning("Overclock engine import failed: %s", exc)
         raise HardwareUnavailable(
             "The overclock engine is unavailable on this system "
             f"({platform.system()}). Hardware actions require Windows with the "
             "AMD driver, the bundled kernel drivers, and Administrator "
-            f"privileges. Details: {exc}"
+            "privileges. See the server console for details."
         ) from exc
     return engine
 
@@ -145,7 +152,13 @@ def run_scan(
             try:
                 hw = engine.init_hardware(skip_dma_discovery=True)
             except Exception as exc:  # noqa: BLE001
-                raise HardwareUnavailable(f"Hardware init failed: {exc}") from exc
+                _log.warning("init_hardware failed: %s", exc)
+                raise HardwareUnavailable(
+                    "Could not initialise the GPU drivers. Make sure the "
+                    "AMD driver and bundled kernel drivers are installed and "
+                    "that the server is running as Administrator. See the "
+                    "server console for details."
+                ) from exc
 
             inpout = hw["inpout"]
             dma_ok = hw.get("virt") is not None
@@ -278,16 +291,24 @@ def apply_boost_clock(
             try:
                 hw = engine.init_hardware(skip_dma_discovery=True)
             except Exception as exc:  # noqa: BLE001
-                raise HardwareUnavailable(f"Hardware init failed: {exc}") from exc
+                _log.warning("init_hardware failed: %s", exc)
+                raise HardwareUnavailable(
+                    "Could not initialise the GPU drivers. Make sure the "
+                    "AMD driver and bundled kernel drivers are installed and "
+                    "that the server is running as Administrator. See the "
+                    "server console for details."
+                ) from exc
 
             inpout, smu = hw["inpout"], hw["smu"]
+            # ``progress`` (the job's set_progress) already records each message
+            # in the job log, so don't also call ``log`` here or lines double up.
             results = engine.apply_clocks_only(
                 inpout,
                 smu,
                 scan_result,
                 settings,
                 vbios_values=vbios,
-                progress_callback=lambda pct, msg: (progress(pct, msg), log(msg)),
+                progress_callback=progress,
             )
             patched = results.get("patched_count", 0)
             skipped = results.get("skipped_count", 0)
@@ -329,7 +350,13 @@ def read_status() -> Dict[str, Any]:
             try:
                 hw = engine.init_hardware(skip_dma_discovery=True)
             except Exception as exc:  # noqa: BLE001
-                raise HardwareUnavailable(f"Hardware init failed: {exc}") from exc
+                _log.warning("init_hardware failed: %s", exc)
+                raise HardwareUnavailable(
+                    "Could not initialise the GPU drivers. Make sure the "
+                    "AMD driver and bundled kernel drivers are installed and "
+                    "that the server is running as Administrator. See the "
+                    "server console for details."
+                ) from exc
 
             smu = hw["smu"]
             state = engine.query_smu_state(smu)
@@ -360,7 +387,13 @@ def read_metrics() -> Dict[str, Any]:
             try:
                 hw = engine.init_hardware(skip_dma_discovery=True)
             except Exception as exc:  # noqa: BLE001
-                raise HardwareUnavailable(f"Hardware init failed: {exc}") from exc
+                _log.warning("init_hardware failed: %s", exc)
+                raise HardwareUnavailable(
+                    "Could not initialise the GPU drivers. Make sure the "
+                    "AMD driver and bundled kernel drivers are installed and "
+                    "that the server is running as Administrator. See the "
+                    "server console for details."
+                ) from exc
 
             if hw.get("virt") is None:
                 raise HardwareUnavailable(

--- a/src/web/jobs.py
+++ b/src/web/jobs.py
@@ -1,0 +1,139 @@
+"""Lightweight background-job manager for the Adrenalift web server.
+
+The desktop GUI runs long operations (memory scan, apply) on ``QThread``
+workers and reports progress through Qt signals.  The web server has no Qt
+event loop, so this module provides an equivalent: jobs run on plain
+``threading.Thread`` objects and expose their progress, streaming log lines,
+final result, and error through a thread-safe :class:`Job` object that the
+HTTP layer polls.
+
+A job target is any callable accepting two keyword callbacks::
+
+    def target(progress, log):
+        progress(50, "halfway")
+        log("did a thing")
+        return {"some": "result"}
+
+``progress(pct, msg)`` and ``log(msg)`` are safe to call from the worker
+thread; the manager serialises access with a lock.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from typing import Any, Callable, Dict, List, Optional
+
+
+class Job:
+    """Thread-safe container tracking a single background operation."""
+
+    def __init__(self, name: str):
+        self.id: str = uuid.uuid4().hex
+        self.name: str = name
+        self.status: str = "pending"  # pending | running | done | error
+        self.progress: float = 0.0
+        self.message: str = ""
+        self.log: List[str] = []
+        self.result: Any = None
+        self.error: Optional[str] = None
+        self.created_at: float = time.time()
+        self.finished_at: Optional[float] = None
+        self._lock = threading.Lock()
+
+    # -- worker-side callbacks -------------------------------------------
+    def set_progress(self, pct: float, msg: str = "") -> None:
+        with self._lock:
+            try:
+                self.progress = max(0.0, min(100.0, float(pct)))
+            except (TypeError, ValueError):
+                pass
+            if msg:
+                self.message = msg
+                self.log.append(msg)
+
+    def add_log(self, msg: str) -> None:
+        if msg is None:
+            return
+        with self._lock:
+            self.message = str(msg)
+            self.log.append(str(msg))
+
+    # -- reader-side snapshot --------------------------------------------
+    def snapshot(self, since: int = 0) -> Dict[str, Any]:
+        """Return a JSON-serialisable view, including log lines after *since*."""
+        with self._lock:
+            since = max(0, int(since or 0))
+            return {
+                "id": self.id,
+                "name": self.name,
+                "status": self.status,
+                "progress": round(self.progress, 1),
+                "message": self.message,
+                "log": list(self.log[since:]),
+                "log_total": len(self.log),
+                "result": self.result if self.status == "done" else None,
+                "error": self.error,
+            }
+
+
+class JobManager:
+    """Owns and runs :class:`Job` instances on background threads."""
+
+    def __init__(self, max_keep: int = 50):
+        self._jobs: Dict[str, Job] = {}
+        self._order: List[str] = []
+        self._max_keep = max_keep
+        self._lock = threading.Lock()
+
+    def submit(self, name: str, target: Callable[..., Any]) -> Job:
+        """Create a job and start *target(progress=..., log=...)* in a thread."""
+        job = Job(name)
+        with self._lock:
+            self._jobs[job.id] = job
+            self._order.append(job.id)
+            self._evict_locked()
+
+        def _run() -> None:
+            job.status = "running"
+            try:
+                result = target(progress=job.set_progress, log=job.add_log)
+                # Mirror the desktop convention where an apply function may
+                # return ``(False, "reason")`` to signal a handled failure.
+                if (
+                    isinstance(result, tuple)
+                    and len(result) == 2
+                    and result[0] is False
+                ):
+                    job.error = str(result[1])
+                    job.status = "error"
+                else:
+                    job.result = result
+                    job.status = "done"
+            except Exception as exc:  # noqa: BLE001 - surface any failure to UI
+                job.error = str(exc) or exc.__class__.__name__
+                job.status = "error"
+                job.add_log(f"Error: {job.error}")
+            finally:
+                job.finished_at = time.time()
+                if job.progress < 100 and job.status == "done":
+                    job.set_progress(100, "")
+
+        threading.Thread(target=_run, name=f"job-{name}", daemon=True).start()
+        return job
+
+    def get(self, job_id: str) -> Optional[Job]:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def _evict_locked(self) -> None:
+        """Drop the oldest finished jobs once we exceed *max_keep*."""
+        while len(self._order) > self._max_keep:
+            old_id = self._order.pop(0)
+            old = self._jobs.get(old_id)
+            if old is not None and old.status in ("pending", "running"):
+                # Never evict an in-flight job; keep it and stop trimming.
+                self._order.insert(0, old_id)
+                break
+            self._jobs.pop(old_id, None)

--- a/src/web/pp_help.py
+++ b/src/web/pp_help.py
@@ -1,0 +1,204 @@
+"""Per-field descriptions and input hints for the PowerPlay-table editor.
+
+The PowerPlay tab shows the *entire* decoded VBIOS PowerPlay table. That tree
+mixes three very different kinds of field:
+
+* **Structural / header fields** -- e.g. ``pmfw_pptable_start_offset`` (the byte
+  offset where the firmware ``PPTable_t`` begins), ``pmfw_*_size``,
+  ``table_revision``, ``golden_pp_id``, ``format_id``, ``reserve``. These
+  describe the *layout* of the table itself. They are **not tunables**; editing
+  them corrupts the table. We mark them read-only.
+* **Firmware tuning fields** -- inside ``smc_pptable`` (SkuTable / BoardTable):
+  clock tables, power/current/temperature limits, voltage and fan settings.
+  Most are firmware-calibrated; only a few are meaningful to change.
+* **Reserved / padding** -- spare bytes; never edit.
+
+AMD does not publish a safe range for every field, so this module is honest
+about what it can know:
+
+* the **storage type** (authoritative, from the decoded struct) gives the hard
+  numeric bounds (uint8 = 0-255, int16 = -32768..32767, float, ...);
+* the **semantic unit / kind** (MHz, mV, degC, watts, amps, %, a 0/1 flag, an
+  offset) is inferred from the field name -- best-effort, clearly hedged;
+* a short **description** explains the field.
+
+Nothing here touches hardware or Qt, so it is fully testable on any platform.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Storage type -> human label + hard numeric bounds
+# ---------------------------------------------------------------------------
+_TYPE_META: Dict[str, Tuple[str, Optional[int], Optional[int]]] = {
+    "B": ("8-bit unsigned integer", 0, 255),
+    "b": ("8-bit signed integer", -128, 127),
+    "H": ("16-bit unsigned integer", 0, 65535),
+    "h": ("16-bit signed integer", -32768, 32767),
+    "I": ("32-bit unsigned integer", 0, 4294967295),
+    "L": ("32-bit unsigned integer", 0, 4294967295),
+    "i": ("32-bit signed integer", -2147483648, 2147483647),
+    "l": ("32-bit signed integer", -2147483648, 2147483647),
+    "f": ("32-bit float", None, None),
+}
+
+
+def type_label(type_code: str) -> str:
+    return _TYPE_META.get(str(type_code), ("integer", None, None))[0]
+
+
+def type_bounds(type_code: str) -> Tuple[Optional[int], Optional[int]]:
+    meta = _TYPE_META.get(str(type_code), ("integer", None, None))
+    return meta[1], meta[2]
+
+
+# ---------------------------------------------------------------------------
+# Curated descriptions for the structural / header fields (exact leaf names
+# from struct_smu_14_0_2_powerplay_table). All read-only.
+# ---------------------------------------------------------------------------
+_STRUCTURAL = {
+    "header": "PowerPlay table header (format, size, revision of the whole table).",
+    "table_revision": "Revision number of this PowerPlay table layout.",
+    "pptable_source": "Identifier of where this PP table came from.",
+    "pmfw_pptable_start_offset": "Byte offset within the table where the firmware "
+    "(PMFW/SMU) PPTable_t begins. A layout pointer, not a setting.",
+    "pmfw_pptable_size": "Size in bytes of the firmware PPTable_t.",
+    "pmfw_sku_table_start_offset": "Byte offset of the SkuTable inside the firmware table.",
+    "pmfw_sku_table_size": "Size in bytes of the SkuTable.",
+    "pmfw_board_table_start_offset": "Byte offset of the BoardTable inside the firmware table.",
+    "pmfw_board_table_size": "Size in bytes of the BoardTable.",
+    "pmfw_custom_sku_table_start_offset": "Byte offset of the CustomSkuTable.",
+    "pmfw_custom_sku_table_size": "Size in bytes of the CustomSkuTable.",
+    "golden_pp_id": "ID of the reference ('golden') PP table this one was derived from.",
+    "golden_revision": "Revision of the reference ('golden') PP table.",
+    "format_id": "PowerPlay table format identifier.",
+    "version": "Struct version stamp.",
+}
+
+# Curated tunable-ish header fields (editable, with units).
+_CURATED = {
+    "platform_caps": ("Bitmask of platform capability flags.", "bitmask", False),
+    "thermal_controller_type": ("Enum selecting the thermal controller hardware.", "enum", False),
+    "small_power_limit1": ("Low power-limit hint.", "W", True),
+    "small_power_limit2": ("Second low power-limit hint.", "W", True),
+    "boost_power_limit": ("Boost power-limit hint.", "W", True),
+    "software_shutdown_temp": ("Emergency shutdown temperature.", "degC", True),
+}
+
+
+# ---------------------------------------------------------------------------
+# Token glossary for the deep firmware fields (checked in order; first match
+# wins). Each entry: (regex, description, unit/kind, editable)
+# ---------------------------------------------------------------------------
+_UNIT_INPUT = {
+    "MHz": "an integer frequency in MHz",
+    "mV": "an integer voltage in millivolts (mV)",
+    "degC": "an integer temperature in degrees Celsius",
+    "W": "an integer power in watts",
+    "A": "an integer current in amps",
+    "%": "a percentage",
+    "RPM": "fan speed in RPM",
+    "PWM": "a fan PWM duty, 0-255",
+    "flag": "a flag: 0 = off/disabled, 1 = on/enabled",
+    "bitmask": "a bitmask (each bit is a separate on/off option)",
+    "enum": "an enumerated code (specific integer values only)",
+    "offset": "a signed offset (can be negative)",
+    "count": "a whole-number count",
+}
+
+_TOKENS = [
+    (r"padding|spare|reserve|reserved|crc|checksum", "Reserved / padding bytes.", "reserved", False),
+    (r"foffset|f_offset", "Frequency offset applied to the clock.", "offset", True),
+    (r"offset", "An offset value.", "offset", True),
+    (r"(gfx|u|f|soc|dcf|disp|dpp|v|d|m)?clk|clock|freq|gfxclk|fclk|uclk|socclk|dclk|vclk|dispclk|dppclk|dcfclk|fmin|fmax",
+     "A clock frequency.", "MHz", True),
+    (r"loadline", "Load-line calibration resistance.", "enum", True),
+    (r"vmax|vmin|voltage|volt|vdd|vddc|vddgfx|vddsoc|mvdd|svi|vid|vboot",
+     "A voltage value.", "mV", True),
+    (r"shutdown_temp|hotspot|tedge|tjmax|tj_|temperature|temp|tedge", "A temperature.", "degC", True),
+    (r"fanpwm|minimumpwm|pwm", "Fan PWM duty.", "PWM", True),
+    (r"acoustic|fanrpm|rpm|fantarget|zerorpm|fan", "A fan-control setting.", "RPM", True),
+    (r"socketpower|boardpower|powerlimit|ppt|tbp|\bpower\b", "A power limit/target.", "W", True),
+    (r"tdc|edc|currentlimit|\bcurrent\b", "A current limit.", "A", True),
+    (r"percent|percentage|\bpct\b", "A percentage value.", "%", True),
+    (r"enable|disable|_en$|ctrl|featurectrl|flag|\bmode\b", "An on/off / mode control.", "flag", True),
+    (r"mask|bitmap|caps", "A bitmask of options.", "bitmask", False),
+    (r"count|num[a-z]*|levels", "A count.", "count", False),
+    (r"throttler|throttle", "A throttler limit or enable.", "enum", True),
+    (r"id$|_id|revision|version|format|source|type$", "An identifier / type code.", "enum", False),
+]
+
+
+def _strip_index(name: str) -> str:
+    return re.sub(r"\[\d+\]", "", name)
+
+
+def describe(path: str, type_code: str = "H") -> Dict[str, object]:
+    """Return {description, unit, editable, type_label, input_hint} for a field."""
+    leaf = _strip_index(path.split(".")[-1])
+    key = leaf.lower()
+    plow = path.lower()
+    tlabel = type_label(type_code)
+    lo, hi = type_bounds(type_code)
+
+    desc: str
+    unit: Optional[str]
+    editable: bool
+
+    if leaf in _STRUCTURAL or key in _STRUCTURAL:
+        desc = _STRUCTURAL.get(leaf) or _STRUCTURAL[key]
+        unit, editable = "structural", False
+    elif leaf in _CURATED or key in _CURATED:
+        d, u, e = _CURATED.get(leaf) or _CURATED[key]
+        desc, unit, editable = d, u, e
+    else:
+        desc, unit, editable = _heuristic(key, plow)
+
+    return {
+        "description": desc,
+        "unit": unit,
+        "editable": editable,
+        "type_label": tlabel,
+        "input_hint": _input_hint(unit, tlabel, lo, hi, editable, type_code),
+    }
+
+
+def _heuristic(key: str, plow: str) -> Tuple[str, str, bool]:
+    # Group context refines a few cases.
+    if "overdrivelimits" in plow:
+        return ("An OverDrive allowed-range bound for this parameter (the min or "
+                "max the firmware will accept).", _unit_from_key(key), True)
+    if "freqtable" in plow:
+        return ("A DPM clock-table frequency point.", "MHz", True)
+    for pattern, desc, unit, editable in _TOKENS:
+        if re.search(pattern, key):
+            return desc, unit, editable
+    return ("Firmware PowerPlay-table field (advanced; meaning not "
+            "documented by AMD).", "raw", True)
+
+
+def _unit_from_key(key: str) -> str:
+    for pattern, _desc, unit, _e in _TOKENS:
+        if re.search(pattern, key):
+            return unit
+    return "raw"
+
+
+def _input_hint(unit, tlabel, lo, hi, editable, type_code) -> str:
+    if not editable:
+        if unit == "structural":
+            return (f"Structural value ({tlabel}) — read-only. Changing it can "
+                    "corrupt the table.")
+        if unit == "reserved":
+            return f"Reserved/padding ({tlabel}) — leave unchanged."
+        return f"{tlabel} — read-only (identifier/bitmask)."
+    bounds = ""
+    if type_code != "f" and lo is not None:
+        bounds = f" (stored as {tlabel}, {lo}–{hi})"
+    elif type_code == "f":
+        bounds = " (stored as a float)"
+    unit_phrase = _UNIT_INPUT.get(unit, "a whole number")
+    return f"Enter {unit_phrase}{bounds}."

--- a/src/web/profiles.py
+++ b/src/web/profiles.py
@@ -1,0 +1,157 @@
+"""File-based tuning-profile store for the Adrenalift web console.
+
+A *profile* is a named bundle of **volatile** tuning settings (power limit,
+boost clock, OverDrive fields, PowerPlay-table field patches, etc.) that the
+user can save, export, import, and re-apply.  Saving a profile writes a JSON
+file to disk -- that is its whole purpose: it is a re-applyable *recipe*.
+
+Crucially, profiles never contain the persistent registry tweaks (those live in
+:mod:`src.web.registry_service` and are quarantined), so applying a profile only
+ever changes volatile GPU/RAM/SMU state.  A reboot always reverts that state;
+the saved profile just lets the user re-apply it afterwards.  There is
+deliberately no "apply on startup" mechanism, which would break that guarantee.
+
+Profiles are stored as ``<settings_dir>/profiles/<slug>.json`` next to the
+executable (frozen) or in the project root (dev), reusing the same directory
+resolution as :mod:`src.app.settings`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from typing import Any, Dict, List, Optional
+
+SCHEMA_VERSION = 1
+
+# Sections a profile may carry.  All are volatile (reboot reverts them); the
+# registry is intentionally absent.
+_ALLOWED_KEYS = {
+    "power_limit_w",
+    "boost_clock_mhz",
+    "gfx_offset_mhz",
+    "od_ppt_pct",
+    "od_fields",      # {od_field_key: number}
+    "pp_fields",      # {offset_str: {"value": number, "type": "H"|"B"|"I"|"f"}}
+    "freq_limits",    # {"gfx_min": int, "gfx_max": int}
+    "smu_features",   # {"enable": [bit,...], "disable": [bit,...]}
+}
+
+
+def _profiles_dir() -> str:
+    try:
+        from src.app.settings import _SETTINGS_DIR
+        base = _SETTINGS_DIR
+    except Exception:  # noqa: BLE001 - fall back to CWD if settings import fails
+        base = os.getcwd()
+    return os.path.join(base, "profiles")
+
+
+def _slug(name: str) -> str:
+    """Turn a profile name into a safe filename stem (no path traversal)."""
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "_", (name or "").strip())
+    slug = slug.strip("._") or "profile"
+    return slug[:64]
+
+
+def _path_for(name: str) -> str:
+    return os.path.join(_profiles_dir(), _slug(name) + ".json")
+
+
+def sanitize_settings(raw: Any) -> Dict[str, Any]:
+    """Keep only known, well-typed sections from a settings dict."""
+    out: Dict[str, Any] = {}
+    if not isinstance(raw, dict):
+        return out
+    for key in _ALLOWED_KEYS:
+        if key in raw and raw[key] is not None:
+            out[key] = raw[key]
+    return out
+
+
+def validate(profile: Any) -> Optional[str]:
+    """Return an error string if *profile* is not a usable profile, else None."""
+    if not isinstance(profile, dict):
+        return "Profile must be a JSON object."
+    name = profile.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return "Profile needs a non-empty 'name'."
+    settings = profile.get("settings")
+    if not isinstance(settings, dict):
+        return "Profile needs a 'settings' object."
+    return None
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+def list_profiles() -> List[Dict[str, Any]]:
+    """Return a summary list of saved profiles (name + metadata, no settings)."""
+    d = _profiles_dir()
+    if not os.path.isdir(d):
+        return []
+    out: List[Dict[str, Any]] = []
+    for fn in sorted(os.listdir(d)):
+        if not fn.endswith(".json"):
+            continue
+        try:
+            with open(os.path.join(d, fn), "r", encoding="utf-8") as f:
+                data = json.load(f)
+            out.append(
+                {
+                    "name": data.get("name", fn[:-5]),
+                    "slug": fn[:-5],
+                    "created_at": data.get("created_at"),
+                    "sections": sorted((data.get("settings") or {}).keys()),
+                }
+            )
+        except Exception:  # noqa: BLE001 - skip unreadable files
+            continue
+    return out
+
+
+def get_profile(name: str) -> Optional[Dict[str, Any]]:
+    path = _path_for(name)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def save_profile(name: str, settings: Any) -> Dict[str, Any]:
+    """Create or overwrite a profile, keeping only known volatile sections."""
+    name = (name or "").strip()
+    if not name:
+        raise ValueError("Profile name is required.")
+    profile = {
+        "schema": SCHEMA_VERSION,
+        "name": name,
+        "created_at": int(time.time()),
+        "settings": sanitize_settings(settings),
+    }
+    os.makedirs(_profiles_dir(), exist_ok=True)
+    with open(_path_for(name), "w", encoding="utf-8") as f:
+        json.dump(profile, f, indent=2)
+    return profile
+
+
+def delete_profile(name: str) -> bool:
+    path = _path_for(name)
+    if os.path.isfile(path):
+        os.remove(path)
+        return True
+    return False
+
+
+def import_profile(payload: Any) -> Dict[str, Any]:
+    """Validate and store an imported profile JSON, returning the stored copy."""
+    err = validate(payload)
+    if err:
+        raise ValueError(err)
+    return save_profile(payload["name"], payload.get("settings"))

--- a/src/web/registry_service.py
+++ b/src/web/registry_service.py
@@ -1,0 +1,193 @@
+"""Quarantined registry-tweak service for the Adrenalift web console.
+
+Unlike every other Adrenalift action, the AMD driver registry tweaks
+(:mod:`src.tools.reg_patch`) are **persistent across reboots** -- they write
+DWORD values under the GPU's Display-Class registry key. That breaks the web
+console's "a restart reverts everything" guarantee, so they are deliberately
+kept out of profiles and isolated behind this service.
+
+To make them behave ephemerally *when possible*, this service:
+
+* takes a backup of the original values before the first apply (handled by
+  :class:`src.tools.reg_patch.RegistryPatch`, which writes ``.reg_backup.json``),
+* exposes a one-click :func:`restore`, and
+* registers an ``atexit`` + SIGINT/SIGTERM handler that auto-restores on a
+  clean server shutdown.
+
+A hard crash or power loss cannot trigger the shutdown hook, so the UI must be
+explicit: registry tweaks survive a reboot until restored, and the backup file
+persists precisely so :func:`restore` can undo them later.
+
+Like :mod:`src.web.hardware_service`, everything here degrades gracefully off
+Windows: the registry is simply reported unavailable.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import platform
+import signal
+import threading
+from typing import Any, Dict, List, Optional
+
+_log = logging.getLogger("adrenalift.web.registry")
+
+_lock = threading.Lock()
+_auto_restore_armed = False
+_applied_once = False
+
+
+def _import_reg():
+    """Import the registry-patch module or raise a clear, safe error."""
+    try:
+        from src.tools import reg_patch
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("reg_patch import failed: %s", exc)
+        raise RegistryUnavailable(
+            "Registry tweaks are unavailable on this system. They require "
+            "Windows with an AMD GPU and Administrator privileges."
+        ) from exc
+    return reg_patch
+
+
+class RegistryUnavailable(RuntimeError):
+    """Raised when the registry tweaks cannot be used (non-Windows / no adapter)."""
+
+
+def available() -> bool:
+    return platform.system() == "Windows"
+
+
+def status() -> Dict[str, Any]:
+    """Non-throwing description of the current registry state for the UI."""
+    info: Dict[str, Any] = {
+        "available": False,
+        "platform": platform.system(),
+        "applied": _applied_once,
+        "reason": "",
+        "adapter": None,
+        "values": None,
+    }
+    if not available():
+        info["reason"] = (
+            "Registry tweaks require Windows with an AMD GPU. They are the only "
+            "settings that survive a reboot, so they live here, separate from "
+            "the ephemeral profiles."
+        )
+        return info
+    try:
+        reg = _import_reg()
+        rp = reg.RegistryPatch()
+        current = rp.read_current()
+        info["available"] = True
+        info["adapter"] = rp.info.get("DriverDesc", "AMD GPU")
+        info["values"] = current
+    except RegistryUnavailable as exc:
+        info["reason"] = str(exc)
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("registry status failed: %s", exc)
+        info["reason"] = (
+            "Could not read the AMD GPU registry key. Make sure the server is "
+            "running as Administrator."
+        )
+    return info
+
+
+def recommended_values() -> Dict[str, int]:
+    """Return the recommended anti-clock-gating value map (safe off-Windows)."""
+    try:
+        reg = _import_reg()
+        return dict(reg.RECOMMENDED_VALUES)
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def _arm_auto_restore() -> None:
+    """Register atexit + signal handlers to restore on clean shutdown (once)."""
+    global _auto_restore_armed
+    if _auto_restore_armed:
+        return
+    _auto_restore_armed = True
+
+    def _restore_quietly(*_args) -> None:
+        try:
+            restore()
+            _log.info("Registry tweaks auto-restored on shutdown.")
+        except Exception as exc:  # noqa: BLE001
+            _log.warning("Auto-restore on shutdown failed: %s", exc)
+
+    atexit.register(_restore_quietly)
+    for sig in (getattr(signal, "SIGINT", None), getattr(signal, "SIGTERM", None)):
+        if sig is None:
+            continue
+        try:
+            prev = signal.getsignal(sig)
+
+            def _handler(signum, frame, _prev=prev):
+                _restore_quietly()
+                # Chain to the previous handler so Ctrl+C still stops the server.
+                if callable(_prev):
+                    _prev(signum, frame)
+                else:
+                    raise KeyboardInterrupt
+
+            signal.signal(sig, _handler)
+        except (ValueError, OSError):
+            # signal.signal only works on the main thread; ignore otherwise.
+            pass
+
+
+def apply(values: Optional[Dict[str, int]] = None) -> Dict[str, Any]:
+    """Apply registry tweaks (recommended set, or a custom value map).
+
+    A backup of the originals is written before the first change, and a
+    shutdown auto-restore hook is armed.
+    """
+    global _applied_once
+    if not available():
+        raise RegistryUnavailable(
+            "Registry tweaks require Windows with an AMD GPU."
+        )
+    reg = _import_reg()
+    with _lock:
+        rp = reg.RegistryPatch()
+        # values=None -> RegistryPatch applies its PATCH_VALUES targets.
+        changes = rp.apply(values=values)
+        _applied_once = True
+        _arm_auto_restore()
+    changed = [
+        {"name": n, "display": reg.REG_NAME_TO_DISPLAY.get(n, n), "old": o, "new": v}
+        for (n, o, v) in changes
+    ]
+    return {
+        "ok": True,
+        "changed_count": len(changed),
+        "changed": changed,
+        "message": (
+            f"Applied {len(changed)} registry change(s). These persist across "
+            "reboots; use Restore (or a clean server shutdown) to revert."
+        ),
+    }
+
+
+def restore() -> Dict[str, Any]:
+    """Restore registry values from the backup written at first apply."""
+    if not available():
+        raise RegistryUnavailable(
+            "Registry tweaks require Windows with an AMD GPU."
+        )
+    reg = _import_reg()
+    with _lock:
+        rp = reg.RegistryPatch()
+        restored = rp.restore()
+    items = [
+        {"name": n, "display": reg.REG_NAME_TO_DISPLAY.get(n, n), "from": c, "to": r}
+        for (n, c, r) in restored
+    ]
+    return {
+        "ok": True,
+        "restored_count": len(items),
+        "restored": items,
+        "message": f"Restored {len(items)} registry value(s) from backup.",
+    }

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -11,6 +11,17 @@ Routes
 ``POST /api/apply/power_limit`` -> set the SMU power (PPT) limit in watts (job id)
 ``POST /api/apply/gfx_offset``  -> set the OverDrive GFX clock offset (job id)
 ``POST /api/apply/od_ppt``      -> set the OverDrive PPT percentage (job id)
+``GET  /api/od``, ``/api/od/layout`` -> OverDrive field values + spec
+``POST /api/apply/od_field``    -> set one OverDrive field (job id)
+``GET  /api/pp``                -> decoded PowerPlay-table field list (editable)
+``POST /api/apply/pp_field``    -> patch one PP-table field in RAM (job id)
+``POST /api/apply/freq_limits`` -> set GFX clock min/max (job id)
+``POST /api/apply/power_lock``  -> lock/unlock GFX power-saving features (job id)
+``POST /api/apply/escape``      -> apply OD via D3DKMTEscape, no admin (job id)
+``GET/POST/DELETE /api/profiles[...]`` -> ephemeral profile CRUD + import/export
+``POST /api/apply/profile``     -> apply a profile's volatile sections (job id)
+``GET  /api/registry``          -> registry-tweak status (PERSISTENT, quarantined)
+``POST /api/registry/apply|restore`` -> apply / restore registry tweaks (job id)
 ``GET  /api/job/<id>``      -> poll a background job (progress + log + result)
 ``GET  /api/status``        -> read SMU state + DPM ranges (synchronous)
 ``GET  /api/metrics``       -> read live GPU metrics (synchronous)
@@ -30,9 +41,11 @@ _ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__
 if _ROOT not in sys.path:
     sys.path.insert(0, _ROOT)
 
-from flask import Flask, jsonify, render_template, request
+from flask import Flask, Response, jsonify, render_template, request
 
 from src.web import hardware_service as hw
+from src.web import profiles as profiles_store
+from src.web import registry_service as registry
 from src.web.jobs import JobManager
 from src.web.tooltips import help_pages, tooltips
 
@@ -97,6 +110,21 @@ def create_app() -> Flask:
     @app.route("/api/metrics/layout")
     def api_metrics_layout():
         return jsonify({"sections": hw.metrics_display_sections()})
+
+    @app.route("/api/od/layout")
+    def api_od_layout():
+        return jsonify({"fields": hw.od_field_layout()})
+
+    @app.route("/api/od")
+    def api_od():
+        try:
+            return jsonify(hw.read_od_fields())
+        except hw.HardwareUnavailable as exc:
+            return jsonify({"ok": False, "error": hw.safe_message(exc)}), 503
+
+    @app.route("/api/pp")
+    def api_pp():
+        return jsonify(hw.pp_field_layout())
 
     # -- background jobs -------------------------------------------------
     @app.route("/api/scan", methods=["POST"])
@@ -203,6 +231,190 @@ def create_app() -> Flask:
             return hw.apply_od_ppt(pct, progress=progress, log=log)
 
         job = jobs.submit("od_ppt", target)
+        return jsonify({"job_id": job.id})
+
+    @app.route("/api/apply/od_field", methods=["POST"])
+    def api_apply_od_field():
+        data = request.get_json(silent=True) or {}
+        key = data.get("key")
+        value = data.get("value")
+        if not key or value is None:
+            return jsonify({"error": "Missing 'key' or 'value'."}), 400
+        try:
+            value = int(value)
+        except (TypeError, ValueError):
+            return jsonify({"error": "'value' must be a whole number."}), 400
+
+        def target(progress, log):
+            return hw.apply_od_field(key, value, progress=progress, log=log)
+
+        job = jobs.submit("od_field", target)
+        return jsonify({"job_id": job.id})
+
+    @app.route("/api/apply/pp_field", methods=["POST"])
+    def api_apply_pp_field():
+        data = request.get_json(silent=True) or {}
+        offset = data.get("offset")
+        value = data.get("value")
+        type_code = str(data.get("type", "H"))
+        if offset is None or value is None:
+            return jsonify({"error": "Missing 'offset' or 'value'."}), 400
+        try:
+            offset = int(offset)
+        except (TypeError, ValueError):
+            return jsonify({"error": "'offset' must be an integer."}), 400
+        if type_code not in ("B", "b", "H", "h", "I", "i", "L", "l", "f"):
+            return jsonify({"error": "Unsupported field 'type'."}), 400
+
+        def target(progress, log):
+            return hw.apply_pp_field(offset, value, type_code, progress=progress, log=log)
+
+        job = jobs.submit("pp_field", target)
+        return jsonify({"job_id": job.id})
+
+    @app.route("/api/apply/freq_limits", methods=["POST"])
+    def api_apply_freq_limits():
+        data = request.get_json(silent=True) or {}
+        try:
+            gfx_min = int(data.get("gfx_min", 0) or 0)
+            gfx_max = int(data.get("gfx_max", 0) or 0)
+        except (TypeError, ValueError):
+            return jsonify({"error": "GFX min/max must be whole numbers."}), 400
+
+        def target(progress, log):
+            return hw.apply_freq_limits(gfx_min, gfx_max, progress=progress, log=log)
+
+        job = jobs.submit("freq_limits", target)
+        return jsonify({"job_id": job.id})
+
+    @app.route("/api/apply/power_lock", methods=["POST"])
+    def api_apply_power_lock():
+        data = request.get_json(silent=True) or {}
+        lock = bool(data.get("lock", True))
+
+        def target(progress, log):
+            return hw.apply_power_saving_lock(lock, progress=progress, log=log)
+
+        job = jobs.submit("power_lock", target)
+        return jsonify({"job_id": job.id})
+
+    @app.route("/api/apply/escape", methods=["POST"])
+    def api_apply_escape():
+        data = request.get_json(silent=True) or {}
+        try:
+            clock = int(data.get("clock", 0) or 0)
+            power = int(data.get("power", 0) or 0)
+            offset = int(data.get("offset", 0) or 0)
+        except (TypeError, ValueError):
+            return jsonify({"error": "clock/power/offset must be whole numbers."}), 400
+
+        def target(progress, log):
+            return hw.apply_escape(clock, power, offset, progress=progress, log=log)
+
+        job = jobs.submit("escape", target)
+        return jsonify({"job_id": job.id})
+
+    # -- profiles (ephemeral recipes; saved to disk, manual-apply only) --
+    @app.route("/api/profiles", methods=["GET"])
+    def api_profiles_list():
+        return jsonify({"profiles": profiles_store.list_profiles()})
+
+    @app.route("/api/profiles", methods=["POST"])
+    def api_profiles_save():
+        data = request.get_json(silent=True) or {}
+        name = data.get("name")
+        if not name:
+            return jsonify({"error": "Missing profile 'name'."}), 400
+        try:
+            saved = profiles_store.save_profile(name, data.get("settings") or {})
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+        return jsonify(saved)
+
+    @app.route("/api/profiles/<name>", methods=["GET"])
+    def api_profiles_get(name: str):
+        prof = profiles_store.get_profile(name)
+        if prof is None:
+            return jsonify({"error": "Unknown profile."}), 404
+        return jsonify(prof)
+
+    @app.route("/api/profiles/<name>", methods=["DELETE"])
+    def api_profiles_delete(name: str):
+        if profiles_store.delete_profile(name):
+            return jsonify({"ok": True})
+        return jsonify({"error": "Unknown profile."}), 404
+
+    @app.route("/api/profiles/<name>/export")
+    def api_profiles_export(name: str):
+        prof = profiles_store.get_profile(name)
+        if prof is None:
+            return jsonify({"error": "Unknown profile."}), 404
+        import json as _json
+        body = _json.dumps(prof, indent=2)
+        return Response(
+            body,
+            mimetype="application/json",
+            headers={
+                "Content-Disposition": f'attachment; filename="{profiles_store._slug(name)}.json"'
+            },
+        )
+
+    @app.route("/api/profiles/import", methods=["POST"])
+    def api_profiles_import():
+        data = request.get_json(silent=True)
+        try:
+            saved = profiles_store.import_profile(data)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+        return jsonify(saved)
+
+    @app.route("/api/apply/profile", methods=["POST"])
+    def api_apply_profile():
+        data = request.get_json(silent=True) or {}
+        # Accept either a saved profile name or an inline settings object.
+        settings = data.get("settings")
+        if settings is None and data.get("name"):
+            prof = profiles_store.get_profile(data["name"])
+            if prof is None:
+                return jsonify({"error": "Unknown profile."}), 404
+            settings = prof.get("settings") or {}
+        if not isinstance(settings, dict):
+            return jsonify({"error": "Provide a profile 'name' or a 'settings' object."}), 400
+
+        def target(progress, log):
+            return hw.apply_profile(settings, progress=progress, log=log)
+
+        job = jobs.submit("profile", target)
+        return jsonify({"job_id": job.id})
+
+    # -- registry tweaks (PERSISTENT; quarantined from profiles) --------
+    @app.route("/api/registry")
+    def api_registry():
+        return jsonify(
+            {"status": registry.status(), "recommended": registry.recommended_values()}
+        )
+
+    @app.route("/api/registry/apply", methods=["POST"])
+    def api_registry_apply():
+        data = request.get_json(silent=True) or {}
+        values = data.get("values")  # optional custom {name: int}; None -> recommended
+        if values is not None and not isinstance(values, dict):
+            return jsonify({"error": "'values' must be an object."}), 400
+
+        def target(progress, log):
+            progress(20, "Applying registry tweaks…")
+            return registry.apply(values)
+
+        job = jobs.submit("registry_apply", target)
+        return jsonify({"job_id": job.id})
+
+    @app.route("/api/registry/restore", methods=["POST"])
+    def api_registry_restore():
+        def target(progress, log):
+            progress(20, "Restoring registry from backup…")
+            return registry.restore()
+
+        job = jobs.submit("registry_restore", target)
         return jsonify({"job_id": job.id})
 
     @app.route("/api/job/<job_id>")

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -128,14 +128,14 @@ def create_app() -> Flask:
         try:
             return jsonify(hw.read_status())
         except hw.HardwareUnavailable as exc:
-            return jsonify({"ok": False, "error": str(exc)}), 503
+            return jsonify({"ok": False, "error": hw.safe_message(exc)}), 503
 
     @app.route("/api/metrics")
     def api_metrics():
         try:
             return jsonify(hw.read_metrics())
         except hw.HardwareUnavailable as exc:
-            return jsonify({"ok": False, "error": str(exc)}), 503
+            return jsonify({"ok": False, "error": hw.safe_message(exc)}), 503
 
     return app
 

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -8,6 +8,9 @@ Routes
 ``GET  /api/tooltips``      -> short tips + descriptions for UI controls
 ``POST /api/scan``          -> start a background memory scan (returns job id)
 ``POST /api/apply/simple``  -> start a background boost-clock apply (job id)
+``POST /api/apply/power_limit`` -> set the SMU power (PPT) limit in watts (job id)
+``POST /api/apply/gfx_offset``  -> set the OverDrive GFX clock offset (job id)
+``POST /api/apply/od_ppt``      -> set the OverDrive PPT percentage (job id)
 ``GET  /api/job/<id>``      -> poll a background job (progress + log + result)
 ``GET  /api/status``        -> read SMU state + DPM ranges (synchronous)
 ``GET  /api/metrics``       -> read live GPU metrics (synchronous)
@@ -39,8 +42,26 @@ except Exception:  # noqa: BLE001 - version is cosmetic
     APP_VERSION, APP_BUILD = "?", "?"
 
 
+def _resource_dir() -> str:
+    """Directory that holds ``templates/`` and ``static/``.
+
+    When frozen by PyInstaller the package source is unpacked under
+    ``sys._MEIPASS`` rather than living next to this module, so Flask's default
+    ``__name__``-based root detection finds nothing.  Resolve it explicitly so
+    the bundled web exe serves its pages correctly.
+    """
+    if getattr(sys, "frozen", False):
+        return os.path.join(sys._MEIPASS, "src", "web")
+    return os.path.dirname(os.path.abspath(__file__))
+
+
 def create_app() -> Flask:
-    app = Flask(__name__)
+    base = _resource_dir()
+    app = Flask(
+        __name__,
+        template_folder=os.path.join(base, "templates"),
+        static_folder=os.path.join(base, "static"),
+    )
     jobs = JobManager()
 
     # -- pages -----------------------------------------------------------
@@ -85,9 +106,15 @@ def create_app() -> Flask:
             num_threads = int(data.get("workers", 0) or 0)
         except (TypeError, ValueError):
             num_threads = 0
+        deep_scan = bool(data.get("deep"))
 
         def target(progress, log):
-            return hw.run_scan(num_threads=num_threads, progress=progress, log=log)
+            return hw.run_scan(
+                num_threads=num_threads,
+                deep_scan=deep_scan,
+                progress=progress,
+                log=log,
+            )
 
         job = jobs.submit("scan", target)
         return jsonify({"job_id": job.id})
@@ -109,6 +136,73 @@ def create_app() -> Flask:
             return hw.apply_boost_clock(clock, progress=progress, log=log)
 
         job = jobs.submit("apply_simple", target)
+        return jsonify({"job_id": job.id})
+
+    @app.route("/api/apply/power_limit", methods=["POST"])
+    def api_apply_power_limit():
+        data = request.get_json(silent=True) or {}
+        watts = data.get("watts")
+        if watts is None:
+            return jsonify({"error": "Missing 'watts'."}), 400
+        try:
+            watts = int(watts)
+        except (TypeError, ValueError):
+            return jsonify({"error": "'watts' must be a whole number."}), 400
+        if not (hw.POWER_LIMIT_MIN_W <= watts <= hw.POWER_LIMIT_MAX_W):
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            f"'watts' must be between {hw.POWER_LIMIT_MIN_W} "
+                            f"and {hw.POWER_LIMIT_MAX_W}."
+                        )
+                    }
+                ),
+                400,
+            )
+
+        def target(progress, log):
+            return hw.set_power_limit(watts, progress=progress, log=log)
+
+        job = jobs.submit("power_limit", target)
+        return jsonify({"job_id": job.id})
+
+    @app.route("/api/apply/gfx_offset", methods=["POST"])
+    def api_apply_gfx_offset():
+        data = request.get_json(silent=True) or {}
+        offset = data.get("offset")
+        if offset is None:
+            return jsonify({"error": "Missing 'offset' (MHz)."}), 400
+        try:
+            offset = int(offset)
+        except (TypeError, ValueError):
+            return jsonify({"error": "'offset' must be a whole number of MHz."}), 400
+        if not (-1000 <= offset <= 1000):
+            return jsonify({"error": "'offset' must be between -1000 and 1000 MHz."}), 400
+
+        def target(progress, log):
+            return hw.apply_gfx_offset(offset, progress=progress, log=log)
+
+        job = jobs.submit("gfx_offset", target)
+        return jsonify({"job_id": job.id})
+
+    @app.route("/api/apply/od_ppt", methods=["POST"])
+    def api_apply_od_ppt():
+        data = request.get_json(silent=True) or {}
+        pct = data.get("pct")
+        if pct is None:
+            return jsonify({"error": "Missing 'pct' (percentage)."}), 400
+        try:
+            pct = int(pct)
+        except (TypeError, ValueError):
+            return jsonify({"error": "'pct' must be a whole number."}), 400
+        if not (-30 <= pct <= 30):
+            return jsonify({"error": "'pct' must be between -30 and 30."}), 400
+
+        def target(progress, log):
+            return hw.apply_od_ppt(pct, progress=progress, log=log)
+
+        job = jobs.submit("od_ppt", target)
         return jsonify({"job_id": job.id})
 
     @app.route("/api/job/<job_id>")

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -1,0 +1,170 @@
+"""Flask web server exposing Adrenalift as a browser application.
+
+Routes
+------
+``GET  /``                  -> single-page UI (templates/index.html)
+``GET  /api/state``         -> engine availability, VBIOS info, last scan
+``GET  /api/help``          -> long-form help pages
+``GET  /api/tooltips``      -> short tips + descriptions for UI controls
+``POST /api/scan``          -> start a background memory scan (returns job id)
+``POST /api/apply/simple``  -> start a background boost-clock apply (job id)
+``GET  /api/job/<id>``      -> poll a background job (progress + log + result)
+``GET  /api/status``        -> read SMU state + DPM ranges (synchronous)
+``GET  /api/metrics``       -> read live GPU metrics (synchronous)
+
+Hardware actions are gated through :mod:`src.web.hardware_service`, which
+degrades gracefully when the Windows-only engine is unavailable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+# Ensure the project root is importable when run as ``python -m src.web``.
+_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from flask import Flask, jsonify, render_template, request
+
+from src.web import hardware_service as hw
+from src.web.jobs import JobManager
+from src.web.tooltips import help_pages, tooltips
+
+try:
+    from src.app.constants import APP_BUILD, APP_VERSION
+except Exception:  # noqa: BLE001 - version is cosmetic
+    APP_VERSION, APP_BUILD = "?", "?"
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    jobs = JobManager()
+
+    # -- pages -----------------------------------------------------------
+    @app.route("/")
+    def index():
+        return render_template(
+            "index.html",
+            app_version=APP_VERSION,
+            app_build=APP_BUILD,
+        )
+
+    # -- metadata --------------------------------------------------------
+    @app.route("/api/state")
+    def api_state():
+        return jsonify(
+            {
+                "version": APP_VERSION,
+                "build": APP_BUILD,
+                "engine": hw.engine_status(),
+                "vbios": hw.vbios_summary(),
+                "last_scan": hw.last_scan_summary(),
+            }
+        )
+
+    @app.route("/api/help")
+    def api_help():
+        return jsonify({"pages": help_pages()})
+
+    @app.route("/api/tooltips")
+    def api_tooltips():
+        return jsonify({"tooltips": tooltips()})
+
+    @app.route("/api/metrics/layout")
+    def api_metrics_layout():
+        return jsonify({"sections": hw.metrics_display_sections()})
+
+    # -- background jobs -------------------------------------------------
+    @app.route("/api/scan", methods=["POST"])
+    def api_scan():
+        data = request.get_json(silent=True) or {}
+        try:
+            num_threads = int(data.get("workers", 0) or 0)
+        except (TypeError, ValueError):
+            num_threads = 0
+
+        def target(progress, log):
+            return hw.run_scan(num_threads=num_threads, progress=progress, log=log)
+
+        job = jobs.submit("scan", target)
+        return jsonify({"job_id": job.id})
+
+    @app.route("/api/apply/simple", methods=["POST"])
+    def api_apply_simple():
+        data = request.get_json(silent=True) or {}
+        clock = data.get("clock")
+        if clock is None:
+            return jsonify({"error": "Missing 'clock' (MHz)."}), 400
+        try:
+            clock = int(clock)
+        except (TypeError, ValueError):
+            return jsonify({"error": "'clock' must be a whole number of MHz."}), 400
+        if not (200 <= clock <= 6000):
+            return jsonify({"error": "'clock' must be between 200 and 6000 MHz."}), 400
+
+        def target(progress, log):
+            return hw.apply_boost_clock(clock, progress=progress, log=log)
+
+        job = jobs.submit("apply_simple", target)
+        return jsonify({"job_id": job.id})
+
+    @app.route("/api/job/<job_id>")
+    def api_job(job_id: str):
+        job = jobs.get(job_id)
+        if job is None:
+            return jsonify({"error": "Unknown job id."}), 404
+        try:
+            since = int(request.args.get("since", 0))
+        except (TypeError, ValueError):
+            since = 0
+        return jsonify(job.snapshot(since=since))
+
+    # -- synchronous read-only -------------------------------------------
+    @app.route("/api/status")
+    def api_status():
+        try:
+            return jsonify(hw.read_status())
+        except hw.HardwareUnavailable as exc:
+            return jsonify({"ok": False, "error": str(exc)}), 503
+
+    @app.route("/api/metrics")
+    def api_metrics():
+        try:
+            return jsonify(hw.read_metrics())
+        except hw.HardwareUnavailable as exc:
+            return jsonify({"ok": False, "error": str(exc)}), 503
+
+    return app
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m src.web",
+        description="Run the Adrenalift web server.",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Interface to bind (default: 127.0.0.1, localhost only).",
+    )
+    parser.add_argument(
+        "--port", type=int, default=8770, help="Port to listen on (default: 8770)."
+    )
+    parser.add_argument(
+        "--debug", action="store_true", help="Enable Flask debug mode."
+    )
+    args = parser.parse_args(argv)
+
+    app = create_app()
+    url = f"http://{args.host}:{args.port}"
+    print(f"Adrenalift web server running at {url}")
+    print("Open that address in your browser. Press Ctrl+C to stop.")
+    app.run(host=args.host, port=args.port, debug=args.debug, threaded=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -1,0 +1,398 @@
+"use strict";
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+const $ = (sel) => document.querySelector(sel);
+const $$ = (sel) => Array.from(document.querySelectorAll(sel));
+
+async function getJSON(url) {
+  const r = await fetch(url);
+  return r.json();
+}
+async function postJSON(url, body) {
+  const r = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body || {}),
+  });
+  return { status: r.status, data: await r.json() };
+}
+
+let TOOLTIPS = {};
+let scanReady = false;
+
+// ---------------------------------------------------------------------------
+// Tabs
+// ---------------------------------------------------------------------------
+$$(".tab").forEach((tab) => {
+  tab.addEventListener("click", () => {
+    $$(".tab").forEach((t) => t.classList.remove("active"));
+    $$(".panel").forEach((p) => p.classList.remove("active"));
+    tab.classList.add("active");
+    $("#tab-" + tab.dataset.tab).classList.add("active");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tooltip popovers (the "extend tooltips & descriptions" feature)
+// ---------------------------------------------------------------------------
+const popover = $("#popover");
+const popoverBody = popover.querySelector(".popover-body");
+
+function showPopover(anchor) {
+  const key = anchor.dataset.help;
+  const t = TOOLTIPS[key];
+  if (!t) return;
+  popoverBody.innerHTML =
+    (t.tip ? `<p><b>${t.tip}</b></p>` : "") +
+    (t.description ? `<p>${t.description}</p>` : "");
+  popover.classList.remove("hidden");
+  const rect = anchor.getBoundingClientRect();
+  let left = rect.left;
+  let top = rect.bottom + 8;
+  // keep on-screen
+  const pw = popover.offsetWidth;
+  if (left + pw > window.innerWidth - 12) left = window.innerWidth - pw - 12;
+  if (left < 12) left = 12;
+  popover.style.left = left + "px";
+  popover.style.top = top + "px";
+}
+function hidePopover() {
+  popover.classList.add("hidden");
+}
+popover.querySelector(".popover-close").addEventListener("click", hidePopover);
+
+function wireHelpAnchors() {
+  $$(".help-anchor").forEach((a) => {
+    const t = TOOLTIPS[a.dataset.help];
+    if (t && t.tip) a.title = t.tip; // native hover tooltip too
+    a.addEventListener("click", (e) => {
+      e.stopPropagation();
+      if (!popover.classList.contains("hidden") && popover.dataset.key === a.dataset.help) {
+        hidePopover();
+        return;
+      }
+      popover.dataset.key = a.dataset.help;
+      showPopover(a);
+    });
+  });
+}
+document.addEventListener("click", (e) => {
+  if (!popover.contains(e.target) && !e.target.classList.contains("help-anchor")) {
+    hidePopover();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+function logLine(msg) {
+  const el = $("#log");
+  el.textContent += (el.textContent ? "\n" : "") + msg;
+  el.scrollTop = el.scrollHeight;
+}
+
+// ---------------------------------------------------------------------------
+// Job polling
+// ---------------------------------------------------------------------------
+function pollJob(jobId, { onProgress, onLog, onDone, onError }) {
+  let since = 0;
+  const timer = setInterval(async () => {
+    let snap;
+    try {
+      snap = await getJSON(`/api/job/${jobId}?since=${since}`);
+    } catch (e) {
+      return; // transient; try again
+    }
+    if (snap.error && snap.status === undefined) {
+      clearInterval(timer);
+      onError && onError(snap.error);
+      return;
+    }
+    since = snap.log_total || since;
+    (snap.log || []).forEach((l) => onLog && onLog(l));
+    onProgress && onProgress(snap.progress, snap.message);
+    if (snap.status === "done") {
+      clearInterval(timer);
+      onDone && onDone(snap.result);
+    } else if (snap.status === "error") {
+      clearInterval(timer);
+      onError && onError(snap.error || "Operation failed.");
+    }
+  }, 600);
+}
+
+// ---------------------------------------------------------------------------
+// Scan
+// ---------------------------------------------------------------------------
+$("#scan-btn").addEventListener("click", async () => {
+  const btn = $("#scan-btn");
+  btn.disabled = true;
+  $("#scan-status").textContent = "Scanning\u2026";
+  $("#scan-progress-wrap").classList.remove("hidden");
+  setProgress("scan", 0, "");
+  const workers = parseInt($("#workers").value, 10) || 0;
+  const { data } = await postJSON("/api/scan", { workers });
+  if (!data.job_id) {
+    $("#scan-status").textContent = data.error || "Could not start scan.";
+    btn.disabled = false;
+    return;
+  }
+  logLine("Scan started\u2026");
+  pollJob(data.job_id, {
+    onProgress: (pct, msg) => setProgress("scan", pct, msg),
+    onLog: (l) => logLine(l),
+    onDone: (result) => {
+      btn.disabled = false;
+      scanReady = result && result.ready_to_apply;
+      $("#apply-btn").disabled = !scanReady;
+      $("#scan-status").textContent = (result && result.message) || "Scan complete.";
+      setProgress("scan", 100, "");
+    },
+    onError: (err) => {
+      btn.disabled = false;
+      $("#scan-status").textContent = "Scan failed.";
+      logLine("Scan failed: " + err);
+    },
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Apply boost clock
+// ---------------------------------------------------------------------------
+$("#apply-btn").addEventListener("click", async () => {
+  const btn = $("#apply-btn");
+  const clock = parseInt($("#clock").value, 10);
+  if (!clock) {
+    logLine("Enter a boost clock in MHz first.");
+    return;
+  }
+  btn.disabled = true;
+  $("#apply-progress-wrap").classList.remove("hidden");
+  setProgress("apply", 0, "");
+  logLine(`Applying ${clock} MHz\u2026`);
+  const { data } = await postJSON("/api/apply/simple", { clock });
+  if (!data.job_id) {
+    logLine(data.error || "Could not start apply.");
+    btn.disabled = false;
+    return;
+  }
+  pollJob(data.job_id, {
+    onProgress: (pct, msg) => setProgress("apply", pct, msg),
+    onLog: (l) => logLine(l),
+    onDone: (result) => {
+      btn.disabled = !scanReady;
+      setProgress("apply", 100, "");
+      logLine((result && result.message) || "Apply complete.");
+    },
+    onError: (err) => {
+      btn.disabled = !scanReady;
+      logLine("Apply failed: " + err);
+    },
+  });
+});
+
+function setProgress(which, pct, msg) {
+  $(`#${which}-progress`).style.width = (pct || 0) + "%";
+  $(`#${which}-progress-label`).textContent = msg || "";
+}
+
+// ---------------------------------------------------------------------------
+// Status
+// ---------------------------------------------------------------------------
+$("#status-btn").addEventListener("click", async () => {
+  const box = $("#status-result");
+  box.innerHTML = '<p class="muted">Reading\u2026</p>';
+  let r;
+  try {
+    r = await fetch("/api/status");
+  } catch (e) {
+    box.innerHTML = errorBox("Network error.");
+    return;
+  }
+  const data = await r.json();
+  if (!data.ok) {
+    box.innerHTML = errorBox(data.error || "Status unavailable.");
+    return;
+  }
+  let rows = [
+    ["SMU version", data.smu_version],
+    ["Driver interface", data.smu_drv_if],
+    ["Power (PPT) limit", data.ppt_limit != null ? data.ppt_limit + " W" : "\u2014"],
+    ["Voltage", data.voltage != null ? data.voltage + " mV" : "\u2014"],
+    ["DMA buffer", data.dma_available ? "available" : "not located"],
+  ];
+  let html = kvTable(rows);
+  if (Array.isArray(data.dpm_ranges) && data.dpm_ranges.length) {
+    html += '<div class="section-title">Clock ranges (MHz)</div>';
+    html += kvTable(
+      data.dpm_ranges.map((d) =>
+        d.error ? [d.name, "error"] : [d.name, `${d.min} \u2013 ${d.max}`]
+      )
+    );
+  }
+  box.innerHTML = html;
+});
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+let metricsTimer = null;
+let metricsLayout = [];
+
+async function loadMetricsLayout() {
+  try {
+    const d = await getJSON("/api/metrics/layout");
+    metricsLayout = d.sections || [];
+  } catch (e) {
+    metricsLayout = [];
+  }
+}
+
+async function readMetrics() {
+  const box = $("#metrics-result");
+  let r;
+  try {
+    r = await fetch("/api/metrics");
+  } catch (e) {
+    box.innerHTML = errorBox("Network error.");
+    return;
+  }
+  const data = await r.json();
+  if (!data.ok) {
+    box.innerHTML = errorBox(data.error || "Metrics unavailable.");
+    stopAuto();
+    return;
+  }
+  const m = data.metrics || {};
+  let html = "";
+  const sections = metricsLayout.length
+    ? metricsLayout
+    : [{ title: "Metrics", keys: Object.keys(m) }];
+  sections.forEach((sec) => {
+    const rows = sec.keys
+      .filter((k) => k in m)
+      .map((k) => [k, formatMetric(m[k])]);
+    if (!rows.length) return;
+    html += `<div class="section-title">${sec.title}</div>` + kvTable(rows);
+  });
+  box.innerHTML = html || '<p class="muted">No metrics returned.</p>';
+}
+
+function formatMetric(v) {
+  if (typeof v === "number" && !Number.isInteger(v)) return v.toFixed(2);
+  if (Array.isArray(v)) return v.join(", ");
+  return String(v);
+}
+
+$("#metrics-btn").addEventListener("click", readMetrics);
+$("#metrics-auto").addEventListener("change", (e) => {
+  if (e.target.checked) {
+    readMetrics();
+    metricsTimer = setInterval(readMetrics, 2000);
+  } else {
+    stopAuto();
+  }
+});
+function stopAuto() {
+  if (metricsTimer) clearInterval(metricsTimer);
+  metricsTimer = null;
+  const cb = $("#metrics-auto");
+  if (cb) cb.checked = false;
+}
+
+// ---------------------------------------------------------------------------
+// Help
+// ---------------------------------------------------------------------------
+async function loadHelp() {
+  const d = await getJSON("/api/help");
+  const list = $("#help-list");
+  list.innerHTML = "";
+  (d.pages || []).forEach((page, i) => {
+    const li = document.createElement("li");
+    li.innerHTML = `<span class="t">${page.title}</span><span class="s">${page.summary}</span>`;
+    li.addEventListener("click", () => {
+      $$("#help-list li").forEach((x) => x.classList.remove("active"));
+      li.classList.add("active");
+      $("#help-body").innerHTML = page.html || '<p class="muted">No content.</p>';
+    });
+    list.appendChild(li);
+    if (i === 0) li.click();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Rendering helpers
+// ---------------------------------------------------------------------------
+function kvTable(rows) {
+  return (
+    '<table class="kv">' +
+    rows
+      .map(
+        ([k, v]) =>
+          `<tr><th>${escapeHtml(k)}</th><td>${escapeHtml(v == null ? "\u2014" : v)}</td></tr>`
+      )
+      .join("") +
+    "</table>"
+  );
+}
+function errorBox(msg) {
+  return `<div class="error-box">${escapeHtml(msg)}</div>`;
+}
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+// ---------------------------------------------------------------------------
+// Boot
+// ---------------------------------------------------------------------------
+async function init() {
+  try {
+    const tip = await getJSON("/api/tooltips");
+    TOOLTIPS = tip.tooltips || {};
+  } catch (e) {
+    TOOLTIPS = {};
+  }
+  wireHelpAnchors();
+
+  try {
+    const state = await getJSON("/api/state");
+    renderBanner(state);
+    if (state.vbios) {
+      $("#vbios-line").textContent = state.vbios.summary || "";
+    }
+    if (state.last_scan && state.last_scan.ready_to_apply) {
+      scanReady = true;
+      $("#apply-btn").disabled = false;
+      $("#scan-status").textContent = state.last_scan.message;
+    }
+  } catch (e) {
+    /* ignore */
+  }
+
+  loadMetricsLayout();
+  loadHelp();
+}
+
+function renderBanner(state) {
+  const banner = $("#banner");
+  if (!state.engine) return;
+  if (state.engine.available) {
+    banner.className = "banner ok";
+    banner.textContent = "GPU engine ready. Scan, then apply your boost clock.";
+  } else {
+    banner.className = "banner warn";
+    banner.textContent =
+      "Hardware actions are unavailable on this host (" +
+      (state.engine.platform || "unknown") +
+      "). You can still browse the UI and help. " +
+      "Run on Windows as Administrator to enable overclocking.";
+  }
+  banner.classList.remove("hidden");
+}
+
+init();

--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -204,54 +204,61 @@ function setProgress(which, pct, msg) {
 // ---------------------------------------------------------------------------
 // Performance tab (power limit, GFX offset, OD PPT) — all job-based
 // ---------------------------------------------------------------------------
-function perfLog(msg) {
-  const el = $("#perf-log");
-  el.textContent += (el.textContent ? "\n" : "") + msg;
-  el.scrollTop = el.scrollHeight;
+// Build a logger that appends to a given <pre> log element.
+function mkLog(selector) {
+  return (msg) => {
+    const el = $(selector);
+    if (!el) return;
+    el.textContent += (el.textContent ? "\n" : "") + msg;
+    el.scrollTop = el.scrollHeight;
+  };
 }
+const perfLog = mkLog("#perf-log");
 
-// Generic "start a background apply job and track it" wired to the
-// Performance-tab controls. `progressKey` is optional (id prefix for a bar).
-async function runApplyJob({ url, body, btn, statusEl, busyMsg, progressKey }) {
-  const button = $(btn);
-  const status = $(statusEl);
-  button.disabled = true;
+// Generic "start a background apply job and track it". `progressKey` is an
+// optional id prefix for a progress bar; `logFn` defaults to the Performance log.
+async function runApplyJob({ url, body, btn, statusEl, busyMsg, progressKey, logFn, onDone }) {
+  const log = logFn || perfLog;
+  const button = btn ? $(btn) : null;
+  const status = statusEl ? $(statusEl) : null;
+  if (button) button.disabled = true;
   if (status) status.textContent = busyMsg;
   if (progressKey) {
     $(`#${progressKey}-progress-wrap`).classList.remove("hidden");
     setProgress(progressKey, 0, "");
   }
-  perfLog(busyMsg);
+  log(busyMsg);
   let resp;
   try {
     resp = await postJSON(url, body);
   } catch (e) {
-    button.disabled = false;
+    if (button) button.disabled = false;
     if (status) status.textContent = "Network error.";
-    perfLog("Network error.");
+    log("Network error.");
     return;
   }
   if (!resp.data.job_id) {
-    button.disabled = false;
+    if (button) button.disabled = false;
     const err = resp.data.error || "Could not start.";
     if (status) status.textContent = err;
-    perfLog(err);
+    log(err);
     return;
   }
   pollJob(resp.data.job_id, {
     onProgress: (pct, msg) => progressKey && setProgress(progressKey, pct, msg),
-    onLog: (l) => perfLog(l),
+    onLog: (l) => log(l),
     onDone: (result) => {
-      button.disabled = false;
+      if (button) button.disabled = false;
       if (progressKey) setProgress(progressKey, 100, "");
       const m = (result && result.message) || "Done.";
       if (status) status.textContent = m;
-      perfLog(m);
+      log(m);
+      if (onDone) onDone(result);
     },
     onError: (err) => {
-      button.disabled = false;
+      if (button) button.disabled = false;
       if (status) status.textContent = err;
-      perfLog("Failed: " + err);
+      log("Failed: " + err);
     },
   });
 }
@@ -459,6 +466,390 @@ function escapeHtml(s) {
 }
 
 // ---------------------------------------------------------------------------
+// Profiles (ephemeral recipes)
+// ---------------------------------------------------------------------------
+function gatherPerfSettings() {
+  const s = {};
+  const pw = parseInt($("#power-watts").value, 10);
+  if (pw) s.power_limit_w = pw;
+  const bc = parseInt($("#clock").value, 10);
+  if (bc) s.boost_clock_mhz = bc;
+  const go = parseInt($("#gfx-offset").value, 10);
+  if (!Number.isNaN(go) && go !== 0) s.gfx_offset_mhz = go;
+  const op = parseInt($("#od-ppt").value, 10);
+  if (!Number.isNaN(op) && op !== 0) s.od_ppt_pct = op;
+  return s;
+}
+
+function fillFormFromProfile(settings) {
+  if (!settings) return;
+  if (settings.power_limit_w != null) $("#power-watts").value = settings.power_limit_w;
+  if (settings.boost_clock_mhz != null) $("#clock").value = settings.boost_clock_mhz;
+  if (settings.gfx_offset_mhz != null) $("#gfx-offset").value = settings.gfx_offset_mhz;
+  if (settings.od_ppt_pct != null) $("#od-ppt").value = settings.od_ppt_pct;
+}
+
+async function refreshProfiles() {
+  let d;
+  try {
+    d = await getJSON("/api/profiles");
+  } catch (e) {
+    return;
+  }
+  const sel = $("#profile-select");
+  const current = sel.value;
+  sel.innerHTML = '<option value="">— saved profiles —</option>';
+  (d.profiles || []).forEach((p) => {
+    const o = document.createElement("option");
+    o.value = p.name;
+    o.textContent = p.name + " (" + (p.sections || []).join(", ") + ")";
+    sel.appendChild(o);
+  });
+  sel.value = current;
+}
+
+function wireProfiles() {
+  $("#profile-save-btn").addEventListener("click", async () => {
+    const name = $("#profile-name").value.trim();
+    if (!name) {
+      $("#profile-status").textContent = "Enter a profile name first.";
+      return;
+    }
+    const { data } = await postJSON("/api/profiles", { name, settings: gatherPerfSettings() });
+    $("#profile-status").textContent = data.error
+      ? data.error
+      : `Saved profile “${name}”.`;
+    if (!data.error) {
+      $("#profile-name").value = "";
+      await refreshProfiles();
+      $("#profile-select").value = name;
+    }
+  });
+
+  $("#profile-apply-btn").addEventListener("click", () => {
+    const name = $("#profile-select").value;
+    if (!name) {
+      $("#profile-status").textContent = "Pick a saved profile first.";
+      return;
+    }
+    runApplyJob({
+      url: "/api/apply/profile",
+      body: { name },
+      btn: "#profile-apply-btn",
+      statusEl: "#profile-status",
+      busyMsg: `Applying profile “${name}”…`,
+      logFn: perfLog,
+    });
+  });
+
+  $("#profile-load-btn").addEventListener("click", async () => {
+    const name = $("#profile-select").value;
+    if (!name) return;
+    const prof = await getJSON("/api/profiles/" + encodeURIComponent(name));
+    fillFormFromProfile(prof.settings);
+    $("#profile-status").textContent = `Loaded “${name}” into the form. Press Apply on each control or use Apply above.`;
+  });
+
+  $("#profile-delete-btn").addEventListener("click", async () => {
+    const name = $("#profile-select").value;
+    if (!name) return;
+    await fetch("/api/profiles/" + encodeURIComponent(name), { method: "DELETE" });
+    $("#profile-status").textContent = `Deleted “${name}”.`;
+    await refreshProfiles();
+  });
+
+  $("#profile-export-btn").addEventListener("click", () => {
+    const name = $("#profile-select").value;
+    if (!name) {
+      $("#profile-status").textContent = "Pick a profile to export.";
+      return;
+    }
+    window.location = "/api/profiles/" + encodeURIComponent(name) + "/export";
+  });
+
+  $("#profile-import-btn").addEventListener("click", () => $("#profile-import-file").click());
+  $("#profile-import-file").addEventListener("change", async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    try {
+      const payload = JSON.parse(await file.text());
+      const { data } = await postJSON("/api/profiles/import", payload);
+      $("#profile-status").textContent = data.error
+        ? data.error
+        : `Imported “${data.name}”.`;
+      if (!data.error) {
+        await refreshProfiles();
+        $("#profile-select").value = data.name;
+      }
+    } catch (err) {
+      $("#profile-status").textContent = "Could not read that file as a profile.";
+    }
+    e.target.value = "";
+  });
+}
+
+// ---------------------------------------------------------------------------
+// OverDrive table editor
+// ---------------------------------------------------------------------------
+const odLog = mkLog("#od-log");
+let odLayout = [];
+
+async function odReadAndRender() {
+  const box = $("#od-result");
+  box.innerHTML = '<p class="muted">Reading OverDrive table…</p>';
+  if (!odLayout.length) {
+    try {
+      odLayout = (await getJSON("/api/od/layout")).fields || [];
+    } catch (e) {
+      odLayout = [];
+    }
+  }
+  let r;
+  try {
+    r = await fetch("/api/od");
+  } catch (e) {
+    box.innerHTML = errorBox("Network error.");
+    return;
+  }
+  const data = await r.json();
+  if (!data.ok) {
+    box.innerHTML = errorBox(data.error || "OverDrive table unavailable.");
+    return;
+  }
+  if (!odLayout.length) {
+    box.innerHTML = errorBox("OverDrive field list unavailable on this host.");
+    return;
+  }
+  const vals = data.values || {};
+  const groups = {};
+  odLayout.forEach((f) => {
+    (groups[f.group] = groups[f.group] || []).push(f);
+  });
+  let html = "";
+  Object.keys(groups).forEach((g) => {
+    html += `<div class="section-title">${escapeHtml(g)}</div><table class="editor">`;
+    groups[g].forEach((f) => {
+      const cur = vals[f.key];
+      html +=
+        `<tr data-row="${escapeHtml(f.key)}"><th>${escapeHtml(f.label)}</th>` +
+        `<td class="cur">${cur == null ? "—" : cur}${f.unit ? " " + escapeHtml(f.unit) : ""}</td>` +
+        `<td><input type="number" class="od-input" value="${cur == null ? 0 : cur}" /></td>` +
+        `<td><button class="set-btn od-set" data-key="${escapeHtml(f.key)}">Set</button></td></tr>`;
+    });
+    html += "</table>";
+  });
+  box.innerHTML = html;
+}
+
+function wireOverdrive() {
+  $("#od-read-btn").addEventListener("click", () => {
+    $("#od-read-btn").disabled = true;
+    odReadAndRender().finally(() => ($("#od-read-btn").disabled = false));
+  });
+  $("#od-filter").addEventListener("input", (e) => filterRows("#od-result", e.target.value));
+  $("#od-result").addEventListener("click", (e) => {
+    const btn = e.target.closest(".od-set");
+    if (!btn) return;
+    const row = btn.closest("tr");
+    const value = parseInt(row.querySelector(".od-input").value, 10);
+    runApplyJob({
+      url: "/api/apply/od_field",
+      body: { key: btn.dataset.key, value },
+      btn: null,
+      statusEl: "#od-status",
+      busyMsg: `Setting ${btn.dataset.key} = ${value}…`,
+      logFn: odLog,
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// PowerPlay table editor
+// ---------------------------------------------------------------------------
+const ppLog = mkLog("#pp-log");
+
+async function ppLoadAndRender() {
+  const box = $("#pp-result");
+  box.innerHTML = '<p class="muted">Decoding PowerPlay table…</p>';
+  let d;
+  try {
+    d = await getJSON("/api/pp");
+  } catch (e) {
+    box.innerHTML = errorBox("Network error.");
+    return;
+  }
+  if (!d.available) {
+    box.innerHTML = errorBox(d.reason || "PowerPlay decoding unavailable.");
+    return;
+  }
+  if (!d.fields.length) {
+    box.innerHTML = '<p class="muted">No editable PP fields found.</p>';
+    return;
+  }
+  let html = `<p class="muted">${d.fields.length} fields. Editing patches RAM (needs a Scan).</p><table class="editor">`;
+  d.fields.forEach((f) => {
+    const v = f.vbios_value == null ? 0 : f.vbios_value;
+    html +=
+      `<tr data-row="${escapeHtml(f.path)}"><th>${escapeHtml(f.path)}</th>` +
+      `<td class="cur">VBIOS: ${escapeHtml(v)} <span class="muted">(${escapeHtml(f.type)})</span></td>` +
+      `<td><input type="number" class="pp-input" value="${escapeHtml(v)}" /></td>` +
+      `<td><button class="set-btn pp-set" data-offset="${f.offset}" data-type="${escapeHtml(f.type)}">Set</button></td></tr>`;
+  });
+  html += "</table>";
+  box.innerHTML = html;
+}
+
+function wirePowerplay() {
+  $("#pp-read-btn").addEventListener("click", () => {
+    $("#pp-read-btn").disabled = true;
+    ppLoadAndRender().finally(() => ($("#pp-read-btn").disabled = false));
+  });
+  $("#pp-filter").addEventListener("input", (e) => filterRows("#pp-result", e.target.value));
+  $("#pp-result").addEventListener("click", (e) => {
+    const btn = e.target.closest(".pp-set");
+    if (!btn) return;
+    const row = btn.closest("tr");
+    const raw = row.querySelector(".pp-input").value;
+    const value = btn.dataset.type === "f" ? parseFloat(raw) : parseInt(raw, 10);
+    runApplyJob({
+      url: "/api/apply/pp_field",
+      body: { offset: parseInt(btn.dataset.offset, 10), value, type: btn.dataset.type },
+      btn: null,
+      statusEl: "#pp-status",
+      busyMsg: `Patching ${row.dataset.row} = ${value}…`,
+      logFn: ppLog,
+    });
+  });
+}
+
+function filterRows(boxSel, term) {
+  term = (term || "").toLowerCase();
+  $$(`${boxSel} tr[data-row]`).forEach((tr) => {
+    tr.style.display = tr.dataset.row.toLowerCase().includes(term) ? "" : "none";
+  });
+}
+
+// ---------------------------------------------------------------------------
+// SMU controls (clock limits, power-saving lock)
+// ---------------------------------------------------------------------------
+const smuLog = mkLog("#smu-log");
+
+function wireSmu() {
+  $("#freq-btn").addEventListener("click", () => {
+    runApplyJob({
+      url: "/api/apply/freq_limits",
+      body: {
+        gfx_min: parseInt($("#gfx-min").value, 10) || 0,
+        gfx_max: parseInt($("#gfx-max").value, 10) || 0,
+      },
+      btn: "#freq-btn",
+      statusEl: "#freq-status",
+      busyMsg: "Applying GFX clock limits…",
+      logFn: smuLog,
+    });
+  });
+  const lock = (val) =>
+    runApplyJob({
+      url: "/api/apply/power_lock",
+      body: { lock: val },
+      btn: val ? "#lock-btn" : "#unlock-btn",
+      statusEl: "#lock-status",
+      busyMsg: val ? "Locking power-saving features…" : "Restoring stock power saving…",
+      logFn: smuLog,
+    });
+  $("#lock-btn").addEventListener("click", () => lock(true));
+  $("#unlock-btn").addEventListener("click", () => lock(false));
+}
+
+// ---------------------------------------------------------------------------
+// Escape (D3DKMTEscape OD8)
+// ---------------------------------------------------------------------------
+const escLog = mkLog("#esc-log");
+
+function wireEscape() {
+  $("#esc-btn").addEventListener("click", () => {
+    runApplyJob({
+      url: "/api/apply/escape",
+      body: {
+        clock: parseInt($("#esc-clock").value, 10) || 0,
+        power: parseInt($("#esc-power").value, 10) || 0,
+        offset: parseInt($("#esc-offset").value, 10) || 0,
+      },
+      btn: "#esc-btn",
+      statusEl: "#esc-status",
+      busyMsg: "Applying OD via D3DKMTEscape…",
+      logFn: escLog,
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// System — registry tweaks (persistent, quarantined)
+// ---------------------------------------------------------------------------
+const regLog = mkLog("#reg-log");
+
+async function regRead() {
+  const box = $("#reg-result");
+  box.innerHTML = '<p class="muted">Reading…</p>';
+  let d;
+  try {
+    d = await getJSON("/api/registry");
+  } catch (e) {
+    box.innerHTML = errorBox("Network error.");
+    return;
+  }
+  const st = d.status || {};
+  if (!st.available) {
+    box.innerHTML = errorBox(st.reason || "Registry tweaks unavailable.");
+    return;
+  }
+  let html = `<p class="muted">Adapter: ${escapeHtml(st.adapter || "AMD GPU")}</p>`;
+  const v = st.values || {};
+  ["patch", "verify", "extra"].forEach((grp) => {
+    const entries = v[grp] || {};
+    const keys = Object.keys(entries);
+    if (!keys.length) return;
+    html += `<div class="section-title">${escapeHtml(grp)}</div>`;
+    html += kvTable(
+      keys.map((k) => [
+        entries[k].desc || k,
+        entries[k].current == null ? "(unset)" : entries[k].current,
+      ])
+    );
+  });
+  box.innerHTML = html;
+}
+
+function wireSystem() {
+  $("#reg-read-btn").addEventListener("click", () => {
+    $("#reg-read-btn").disabled = true;
+    regRead().finally(() => ($("#reg-read-btn").disabled = false));
+  });
+  $("#reg-apply-btn").addEventListener("click", () => {
+    runApplyJob({
+      url: "/api/registry/apply",
+      body: {},
+      btn: "#reg-apply-btn",
+      statusEl: "#reg-status",
+      busyMsg: "Applying recommended registry tweaks…",
+      logFn: regLog,
+      onDone: () => regRead(),
+    });
+  });
+  $("#reg-restore-btn").addEventListener("click", () => {
+    runApplyJob({
+      url: "/api/registry/restore",
+      body: {},
+      btn: "#reg-restore-btn",
+      statusEl: "#reg-status",
+      busyMsg: "Restoring registry from backup…",
+      logFn: regLog,
+      onDone: () => regRead(),
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Boot
 // ---------------------------------------------------------------------------
 async function init() {
@@ -488,6 +879,13 @@ async function init() {
     /* ignore */
   }
 
+  wireProfiles();
+  wireOverdrive();
+  wirePowerplay();
+  wireSmu();
+  wireEscape();
+  wireSystem();
+  refreshProfiles();
   loadMetricsLayout();
   loadHelp();
 }

--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -686,17 +686,42 @@ async function ppLoadAndRender() {
     box.innerHTML = '<p class="muted">No editable PP fields found.</p>';
     return;
   }
-  let html = `<p class="muted">${d.fields.length} fields. Editing patches RAM (needs a Scan).</p><table class="editor">`;
+  const tunable = d.fields.filter((f) => f.editable).length;
+  let html =
+    `<p class="muted">${d.fields.length} fields total · ${tunable} editable. ` +
+    `Editing patches RAM across all scanned copies (needs a Scan). A reboot restores stock.</p>` +
+    `<table class="editor">`;
   d.fields.forEach((f) => {
     const v = f.vbios_value == null ? 0 : f.vbios_value;
+    const ro = !f.editable;
+    const desc = escapeHtml(f.description || "");
+    const hint = escapeHtml(f.input_hint || "");
     html +=
-      `<tr data-row="${escapeHtml(f.path)}"><th>${escapeHtml(f.path)}</th>` +
-      `<td class="cur">VBIOS: ${escapeHtml(v)} <span class="muted">(${escapeHtml(f.type)})</span></td>` +
-      `<td><input type="number" class="pp-input" value="${escapeHtml(v)}" /></td>` +
-      `<td><button class="set-btn pp-set" data-offset="${f.offset}" data-type="${escapeHtml(f.type)}">Set</button></td></tr>`;
+      `<tr data-row="${escapeHtml(f.path)}" data-editable="${f.editable ? 1 : 0}">` +
+      `<th title="${desc}">${escapeHtml(f.path)}` +
+      (ro ? ' <span class="tag-ro">read-only</span>' : "") +
+      `<span class="field-hint">${hint}</span></th>` +
+      `<td class="cur">VBIOS: ${escapeHtml(v)} <span class="muted">(${escapeHtml(f.type_label || f.type)})</span></td>` +
+      `<td><input type="number" class="pp-input" value="${escapeHtml(v)}" ${ro ? "disabled" : ""} /></td>` +
+      `<td>${
+        ro
+          ? '<span class="muted">—</span>'
+          : `<button class="set-btn pp-set" data-offset="${f.offset}" data-type="${escapeHtml(f.type)}">Set</button>`
+      }</td></tr>`;
   });
   html += "</table>";
   box.innerHTML = html;
+  applyPpVisibility();
+}
+
+function applyPpVisibility() {
+  const tunableOnly = $("#pp-tunable-only") && $("#pp-tunable-only").checked;
+  const term = ($("#pp-filter").value || "").toLowerCase();
+  $$("#pp-result tr[data-row]").forEach((tr) => {
+    const matchText = tr.dataset.row.toLowerCase().includes(term);
+    const matchTun = !tunableOnly || tr.dataset.editable === "1";
+    tr.style.display = matchText && matchTun ? "" : "none";
+  });
 }
 
 function wirePowerplay() {
@@ -704,7 +729,8 @@ function wirePowerplay() {
     $("#pp-read-btn").disabled = true;
     ppLoadAndRender().finally(() => ($("#pp-read-btn").disabled = false));
   });
-  $("#pp-filter").addEventListener("input", (e) => filterRows("#pp-result", e.target.value));
+  $("#pp-filter").addEventListener("input", applyPpVisibility);
+  $("#pp-tunable-only").addEventListener("change", applyPpVisibility);
   $("#pp-result").addEventListener("click", (e) => {
     const btn = e.target.closest(".pp-set");
     if (!btn) return;

--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -135,7 +135,8 @@ $("#scan-btn").addEventListener("click", async () => {
   $("#scan-progress-wrap").classList.remove("hidden");
   setProgress("scan", 0, "");
   const workers = parseInt($("#workers").value, 10) || 0;
-  const { data } = await postJSON("/api/scan", { workers });
+  const deep = $("#deep-scan").checked;
+  const { data } = await postJSON("/api/scan", { workers, deep });
   if (!data.job_id) {
     $("#scan-status").textContent = data.error || "Could not start scan.";
     btn.disabled = false;
@@ -199,6 +200,113 @@ function setProgress(which, pct, msg) {
   $(`#${which}-progress`).style.width = (pct || 0) + "%";
   $(`#${which}-progress-label`).textContent = msg || "";
 }
+
+// ---------------------------------------------------------------------------
+// Performance tab (power limit, GFX offset, OD PPT) — all job-based
+// ---------------------------------------------------------------------------
+function perfLog(msg) {
+  const el = $("#perf-log");
+  el.textContent += (el.textContent ? "\n" : "") + msg;
+  el.scrollTop = el.scrollHeight;
+}
+
+// Generic "start a background apply job and track it" wired to the
+// Performance-tab controls. `progressKey` is optional (id prefix for a bar).
+async function runApplyJob({ url, body, btn, statusEl, busyMsg, progressKey }) {
+  const button = $(btn);
+  const status = $(statusEl);
+  button.disabled = true;
+  if (status) status.textContent = busyMsg;
+  if (progressKey) {
+    $(`#${progressKey}-progress-wrap`).classList.remove("hidden");
+    setProgress(progressKey, 0, "");
+  }
+  perfLog(busyMsg);
+  let resp;
+  try {
+    resp = await postJSON(url, body);
+  } catch (e) {
+    button.disabled = false;
+    if (status) status.textContent = "Network error.";
+    perfLog("Network error.");
+    return;
+  }
+  if (!resp.data.job_id) {
+    button.disabled = false;
+    const err = resp.data.error || "Could not start.";
+    if (status) status.textContent = err;
+    perfLog(err);
+    return;
+  }
+  pollJob(resp.data.job_id, {
+    onProgress: (pct, msg) => progressKey && setProgress(progressKey, pct, msg),
+    onLog: (l) => perfLog(l),
+    onDone: (result) => {
+      button.disabled = false;
+      if (progressKey) setProgress(progressKey, 100, "");
+      const m = (result && result.message) || "Done.";
+      if (status) status.textContent = m;
+      perfLog(m);
+    },
+    onError: (err) => {
+      button.disabled = false;
+      if (status) status.textContent = err;
+      perfLog("Failed: " + err);
+    },
+  });
+}
+
+$("#power-btn").addEventListener("click", () => {
+  const watts = parseInt($("#power-watts").value, 10);
+  if (!watts) {
+    perfLog("Enter a power limit in watts first.");
+    return;
+  }
+  runApplyJob({
+    url: "/api/apply/power_limit",
+    body: { watts },
+    btn: "#power-btn",
+    statusEl: "#power-status",
+    busyMsg: `Setting power limit to ${watts} W…`,
+    progressKey: "power",
+  });
+});
+
+$("#power-template-btn").addEventListener("click", () => {
+  $("#power-watts").value = 340;
+  $("#power-btn").click();
+});
+
+$("#gfx-offset-btn").addEventListener("click", () => {
+  const offset = parseInt($("#gfx-offset").value, 10);
+  if (Number.isNaN(offset)) {
+    perfLog("Enter a GFX offset in MHz first.");
+    return;
+  }
+  runApplyJob({
+    url: "/api/apply/gfx_offset",
+    body: { offset },
+    btn: "#gfx-offset-btn",
+    statusEl: "#gfx-offset-status",
+    busyMsg: `Applying GFX offset ${offset >= 0 ? "+" : ""}${offset} MHz…`,
+    progressKey: "gfxoff",
+  });
+});
+
+$("#od-ppt-btn").addEventListener("click", () => {
+  const pct = parseInt($("#od-ppt").value, 10);
+  if (Number.isNaN(pct)) {
+    perfLog("Enter an OD PPT percentage first.");
+    return;
+  }
+  runApplyJob({
+    url: "/api/apply/od_ppt",
+    body: { pct },
+    btn: "#od-ppt-btn",
+    statusEl: "#od-ppt-status",
+    busyMsg: `Applying OD PPT ${pct >= 0 ? "+" : ""}${pct}%…`,
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Status
@@ -366,7 +474,10 @@ async function init() {
     const state = await getJSON("/api/state");
     renderBanner(state);
     if (state.vbios) {
-      $("#vbios-line").textContent = state.vbios.summary || "";
+      const summary = state.vbios.summary || "";
+      $("#vbios-line").textContent = summary;
+      const pv = $("#perf-vbios-line");
+      if (pv) pv.textContent = summary;
     }
     if (state.last_scan && state.last_scan.ready_to_apply) {
       scanReady = true;

--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -105,9 +105,11 @@ function pollJob(jobId, { onProgress, onLog, onDone, onError }) {
     } catch (e) {
       return; // transient; try again
     }
-    if (snap.error && snap.status === undefined) {
+    // 404 / unknown-job response: {"error": ...} with no job fields at all.
+    // (A finished-but-failed job instead has status === "error", handled below.)
+    if (snap.status === undefined) {
       clearInterval(timer);
-      onError && onError(snap.error);
+      onError && onError(snap.error || "Job not found.");
       return;
     }
     since = snap.log_total || since;

--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -120,7 +120,7 @@ function pollJob(jobId, { onProgress, onLog, onDone, onError }) {
       clearInterval(timer);
       onError && onError(snap.error || "Operation failed.");
     }
-  }, 600);
+  }, 1000);
 }
 
 // ---------------------------------------------------------------------------
@@ -281,6 +281,7 @@ async function readMetrics() {
 }
 
 function formatMetric(v) {
+  if (v == null) return "\u2014";
   if (typeof v === "number" && !Number.isInteger(v)) return v.toFixed(2);
   if (Array.isArray(v)) return v.join(", ");
   return String(v);

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -180,7 +180,15 @@ table.editor th, table.editor td {
 table.editor th { color: var(--text); font-weight: 500; width: 40%; word-break: break-all; }
 table.editor td.cur { color: var(--muted); width: 28%; }
 table.editor input { width: 110px; padding: 4px 6px; }
+table.editor input:disabled { opacity: 0.5; }
 table.editor button.set-btn { padding: 4px 12px; font-size: 12px; }
+table.editor th { cursor: help; }
+.field-hint { display: block; color: var(--muted); font-size: 11px; font-weight: 400; margin-top: 2px; }
+.tag-ro {
+  display: inline-block; font-size: 10px; font-weight: 600;
+  color: var(--muted); border: 1px solid var(--border); border-radius: 4px;
+  padding: 0 5px; margin-left: 6px; vertical-align: middle;
+}
 .result { max-height: 60vh; overflow: auto; }
 input[type="search"] { flex: 1; min-width: 140px; }
 

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -1,0 +1,234 @@
+:root {
+  --bg: #1b1d21;
+  --panel: #24272c;
+  --panel-2: #2c3038;
+  --border: #3a3f47;
+  --text: #e6e8ea;
+  --muted: #9aa0a8;
+  --accent: #e8612c;
+  --accent-hover: #ff7a45;
+  --warn: #d8a200;
+  --ok: #4caf76;
+  --err: #e0574b;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", system-ui, -apple-system, Roboto, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 14px;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 20px;
+  background: linear-gradient(90deg, #2a2d33, #24272c);
+  border-bottom: 1px solid var(--border);
+}
+.brand .logo { font-size: 20px; font-weight: 700; color: var(--accent); }
+.brand .tagline { margin-left: 10px; color: var(--muted); font-size: 12px; }
+.version { color: var(--muted); font-size: 12px; }
+
+.banner {
+  margin: 12px 20px 0;
+  padding: 10px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+  color: var(--muted);
+  font-size: 13px;
+}
+.banner.ok { border-color: #2f5f45; color: #bfe6cf; }
+.banner.warn { border-color: #6b5a1f; color: #f0dca0; }
+
+.tabs {
+  display: flex;
+  gap: 4px;
+  padding: 12px 20px 0;
+}
+.tab {
+  background: var(--panel);
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-bottom: none;
+  padding: 9px 18px;
+  border-radius: 8px 8px 0 0;
+  cursor: pointer;
+  font-size: 14px;
+}
+.tab:hover { color: var(--text); }
+.tab.active { background: var(--panel-2); color: var(--text); font-weight: 600; }
+
+main { padding: 0 20px 40px; }
+
+.panel { display: none; padding-top: 16px; }
+.panel.active { display: block; }
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px 18px;
+  margin-bottom: 16px;
+}
+.card h2 { margin: 0 0 8px; }
+.card h3 { margin: 0 0 12px; font-size: 16px; }
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+label { color: var(--muted); }
+
+input[type="number"] {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 5px;
+  padding: 7px 9px;
+  width: 110px;
+  font-size: 14px;
+}
+.checkbox { display: inline-flex; align-items: center; gap: 6px; }
+
+button {
+  font-size: 14px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+  color: var(--text);
+  padding: 8px 16px;
+  cursor: pointer;
+}
+button:hover { background: #353a43; }
+button.primary { background: var(--accent); border-color: var(--accent); color: #fff; font-weight: 600; }
+button.primary:hover { background: var(--accent-hover); }
+button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.muted { color: var(--muted); }
+.status { margin: 10px 0 0; }
+.warn { color: var(--warn); font-size: 13px; }
+
+.progress { margin-top: 12px; }
+.progress-bar {
+  height: 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.progress-fill {
+  height: 100%;
+  width: 0%;
+  background: var(--accent);
+  transition: width 0.2s ease;
+}
+
+.log {
+  background: #15171a;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px;
+  max-height: 260px;
+  overflow: auto;
+  white-space: pre-wrap;
+  font-family: "Cascadia Code", Consolas, monospace;
+  font-size: 12px;
+  color: #cfd3d8;
+  margin: 0;
+}
+
+.result { margin-top: 12px; }
+table.kv { border-collapse: collapse; width: 100%; }
+table.kv th, table.kv td {
+  text-align: left;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+table.kv th { color: var(--muted); font-weight: 600; width: 45%; }
+.section-title { margin: 16px 0 6px; color: var(--accent); font-weight: 600; }
+
+.error-box {
+  border: 1px solid #5c3330;
+  background: #2c2422;
+  color: #f0b8b0;
+  padding: 10px 12px;
+  border-radius: 6px;
+}
+
+/* Help tab */
+.help-layout { display: flex; gap: 16px; align-items: flex-start; }
+.help-nav { width: 260px; flex-shrink: 0; }
+.help-nav ul { list-style: none; padding: 0; margin: 0; }
+.help-nav li {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  background: var(--panel);
+}
+.help-nav li:hover { background: var(--panel-2); }
+.help-nav li.active { border-color: var(--accent); }
+.help-nav li .t { font-weight: 600; display: block; }
+.help-nav li .s { color: var(--muted); font-size: 12px; }
+.help-body { flex: 1; min-width: 0; line-height: 1.5; }
+.help-body h3, .help-body h4 { color: var(--accent); }
+.help-body table { border-collapse: collapse; }
+.help-body td, .help-body th { border: 1px solid var(--border); padding: 4px 8px; }
+
+/* Help anchors / popovers */
+.help-anchor {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 17px;
+  height: 17px;
+  border-radius: 50%;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  cursor: help;
+  vertical-align: middle;
+  user-select: none;
+}
+.help-anchor::before { content: "?"; }
+.help-anchor:hover { color: var(--text); border-color: var(--accent); }
+.help-anchor.light { background: rgba(255,255,255,0.2); color: #fff; border-color: rgba(255,255,255,0.4); }
+
+.popover {
+  position: fixed;
+  max-width: 340px;
+  background: var(--panel-2);
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  padding: 14px 16px 16px;
+  box-shadow: 0 8px 28px rgba(0,0,0,0.5);
+  z-index: 50;
+  font-size: 13px;
+  line-height: 1.45;
+}
+.popover-body b { color: var(--text); }
+.popover-close {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 18px;
+  padding: 0 6px;
+}
+
+.hidden { display: none !important; }

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -168,6 +168,22 @@ table.kv th, table.kv td {
 table.kv th { color: var(--muted); font-weight: 600; width: 45%; }
 .section-title { margin: 16px 0 6px; color: var(--accent); font-weight: 600; }
 
+/* OD / PP field editors */
+table.editor { border-collapse: collapse; width: 100%; }
+table.editor th, table.editor td {
+  text-align: left;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  vertical-align: middle;
+}
+table.editor th { color: var(--text); font-weight: 500; width: 40%; word-break: break-all; }
+table.editor td.cur { color: var(--muted); width: 28%; }
+table.editor input { width: 110px; padding: 4px 6px; }
+table.editor button.set-btn { padding: 4px 12px; font-size: 12px; }
+.result { max-height: 60vh; overflow: auto; }
+input[type="search"] { flex: 1; min-width: 140px; }
+
 .error-box {
   border: 1px solid #5c3330;
   background: #2c2422;

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -112,6 +112,17 @@ button:hover { background: #353a43; }
 button.primary { background: var(--accent); border-color: var(--accent); color: #fff; font-weight: 600; }
 button.primary:hover { background: var(--accent-hover); }
 button:disabled { opacity: 0.5; cursor: not-allowed; }
+button.ghost { background: transparent; border-style: dashed; color: var(--muted); }
+button.ghost:hover { background: var(--panel-2); color: var(--text); }
+
+details.card > summary {
+  cursor: pointer;
+  font-size: 15px;
+  list-style: none;
+}
+details.card > summary::-webkit-details-marker { display: none; }
+details.card > summary::before { content: "\25B8  "; color: var(--muted); }
+details.card[open] > summary::before { content: "\25BE  "; }
 
 .muted { color: var(--muted); }
 .status { margin: 10px 0 0; }

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -20,8 +20,13 @@
   <nav class="tabs" role="tablist">
     <button class="tab active" data-tab="performance" role="tab">Performance</button>
     <button class="tab" data-tab="home" role="tab">Boost Clock</button>
-    <button class="tab" data-tab="status" role="tab">Status</button>
+    <button class="tab" data-tab="overdrive" role="tab">OverDrive</button>
+    <button class="tab" data-tab="powerplay" role="tab">PowerPlay</button>
+    <button class="tab" data-tab="smu" role="tab">SMU</button>
+    <button class="tab" data-tab="escape" role="tab">Escape</button>
     <button class="tab" data-tab="metrics" role="tab">Metrics</button>
+    <button class="tab" data-tab="status" role="tab">Status</button>
+    <button class="tab" data-tab="system" role="tab">System</button>
     <button class="tab" data-tab="help" role="tab">Help</button>
   </nav>
 
@@ -36,6 +41,30 @@
           reboot restores stock values.
         </p>
         <p id="perf-vbios-line" class="muted"></p>
+      </div>
+
+      <div class="card">
+        <h3>Profiles <span class="help-anchor" data-help="profiles"></span></h3>
+        <p class="muted">
+          Save the current Performance settings as a reusable profile, or load
+          and apply a saved one. Profiles are files you can export/import.
+          They never include the persistent registry tweaks, and nothing is
+          applied automatically &mdash; a reboot still reverts everything.
+        </p>
+        <div class="row">
+          <select id="profile-select"><option value="">— saved profiles —</option></select>
+          <button id="profile-apply-btn" class="primary">Apply</button>
+          <button id="profile-load-btn" class="ghost">Load into form</button>
+          <button id="profile-delete-btn" class="ghost">Delete</button>
+        </div>
+        <div class="row">
+          <input type="text" id="profile-name" placeholder="New profile name" />
+          <button id="profile-save-btn">Save current</button>
+          <button id="profile-export-btn" class="ghost">Export selected</button>
+          <button id="profile-import-btn" class="ghost">Import…</button>
+          <input type="file" id="profile-import-file" accept="application/json,.json" hidden />
+        </div>
+        <p id="profile-status" class="status muted"></p>
       </div>
 
       <div class="card">
@@ -184,6 +213,118 @@
         </div>
         <div id="metrics-result" class="result"></div>
       </div>
+    </section>
+
+    <!-- ========================== OVERDRIVE ========================== -->
+    <section id="tab-overdrive" class="panel" role="tabpanel">
+      <div class="card">
+        <h3>OverDrive table <span class="help-anchor" data-help="overdrive"></span></h3>
+        <p class="muted">
+          The firmware OverDrive table: clock offsets, voltage, power, fan and
+          temperature limits. Needs a <b>deep scan</b> first (Boost Clock tab).
+          Each field is applied individually. All changes revert on reboot.
+        </p>
+        <div class="row">
+          <button id="od-read-btn" class="primary">Read OverDrive table</button>
+          <input type="search" id="od-filter" placeholder="Filter fields…" />
+        </div>
+        <div id="od-result" class="result"><p class="muted">Press “Read OverDrive table”.</p></div>
+        <p id="od-status" class="status muted"></p>
+      </div>
+      <div class="card"><h3>Activity log</h3><pre id="od-log" class="log"></pre></div>
+    </section>
+
+    <!-- ========================== POWERPLAY ========================== -->
+    <section id="tab-powerplay" class="panel" role="tabpanel">
+      <div class="card">
+        <h3>PowerPlay table editor <span class="help-anchor" data-help="powerplay"></span></h3>
+        <p class="muted">
+          Every decoded field of the driver's cached PowerPlay table. Editing a
+          field patches it in RAM across all scanned copies (needs a <b>Scan</b>
+          first). This is for power users &mdash; wrong values can crash the
+          driver. A reboot restores everything.
+        </p>
+        <div class="row">
+          <button id="pp-read-btn" class="primary">Load PP fields</button>
+          <input type="search" id="pp-filter" placeholder="Filter fields…" />
+        </div>
+        <div id="pp-result" class="result"><p class="muted">Press “Load PP fields”.</p></div>
+        <p id="pp-status" class="status muted"></p>
+      </div>
+      <div class="card"><h3>Activity log</h3><pre id="pp-log" class="log"></pre></div>
+    </section>
+
+    <!-- ============================= SMU ============================= -->
+    <section id="tab-smu" class="panel" role="tabpanel">
+      <div class="card">
+        <h3>GFX clock limits <span class="help-anchor" data-help="freq_limits"></span></h3>
+        <p class="muted">Pin the graphics clock to a min/max window (MHz). Leave a field 0 to skip it.</p>
+        <div class="row">
+          <label for="gfx-min">GFX min</label>
+          <input type="number" id="gfx-min" min="0" max="4000" step="5" value="0" />
+          <label for="gfx-max">GFX max</label>
+          <input type="number" id="gfx-max" min="0" max="4000" step="5" value="0" />
+          <button id="freq-btn" class="primary">Apply clock limits</button>
+        </div>
+        <p id="freq-status" class="status muted"></p>
+      </div>
+      <div class="card">
+        <h3>Power-saving lock <span class="help-anchor" data-help="power_lock"></span></h3>
+        <p class="muted">
+          Disable the idle/clock-gating features (DS_GFXCLK, GFX_ULV, GFXOFF)
+          that cause downclocking, or re-enable them. Reverts on reboot.
+        </p>
+        <div class="row">
+          <button id="lock-btn" class="primary">Lock (disable power saving)</button>
+          <button id="unlock-btn" class="ghost">Unlock (restore stock)</button>
+        </div>
+        <p id="lock-status" class="status muted"></p>
+      </div>
+      <div class="card"><h3>Activity log</h3><pre id="smu-log" class="log"></pre></div>
+    </section>
+
+    <!-- =========================== ESCAPE =========================== -->
+    <section id="tab-escape" class="panel" role="tabpanel">
+      <div class="card">
+        <h3>D3DKMTEscape OD8 <span class="help-anchor" data-help="escape"></span></h3>
+        <p class="muted">
+          An alternate path that sends OD settings through the WDDM
+          D3DKMTEscape interface &mdash; the same channel AMD Adrenalin uses, and
+          it does <b>not</b> require Administrator. Leave a field 0 to skip it.
+        </p>
+        <div class="row">
+          <label for="esc-clock">Clock ceiling (MHz)</label>
+          <input type="number" id="esc-clock" min="0" max="5000" step="5" value="0" />
+          <label for="esc-power">Power (W)</label>
+          <input type="number" id="esc-power" min="0" max="600" step="1" value="0" />
+          <label for="esc-offset">GFX offset (MHz)</label>
+          <input type="number" id="esc-offset" min="-1000" max="1000" step="5" value="0" />
+          <button id="esc-btn" class="primary">Apply via Escape</button>
+        </div>
+        <p id="esc-status" class="status muted"></p>
+      </div>
+      <div class="card"><h3>Activity log</h3><pre id="esc-log" class="log"></pre></div>
+    </section>
+
+    <!-- =========================== SYSTEM =========================== -->
+    <section id="tab-system" class="panel" role="tabpanel">
+      <div class="card">
+        <h2>System &mdash; persistent tweaks <span class="help-anchor" data-help="registry"></span></h2>
+        <p class="warn">
+          &#9888; Unlike everything else in Adrenalift, these registry tweaks
+          <b>survive a reboot</b>. A backup is taken before the first apply;
+          use <b>Restore</b> (or a clean server shutdown, which auto-restores)
+          to revert. A hard crash or power loss will not auto-revert.
+        </p>
+        <div class="row">
+          <button id="reg-read-btn" class="primary">Read registry status</button>
+          <button id="reg-apply-btn">Apply recommended</button>
+          <button id="reg-restore-btn" class="ghost">Restore from backup</button>
+        </div>
+        <div id="reg-result" class="result"></div>
+        <p id="reg-status" class="status muted"></p>
+      </div>
+      <div class="card"><h3>Activity log</h3><pre id="reg-log" class="log"></pre></div>
     </section>
 
     <!-- ============================ HELP ============================ -->

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -18,15 +18,90 @@
   <div id="banner" class="banner hidden"></div>
 
   <nav class="tabs" role="tablist">
-    <button class="tab active" data-tab="home" role="tab">Boost Clock</button>
+    <button class="tab active" data-tab="performance" role="tab">Performance</button>
+    <button class="tab" data-tab="home" role="tab">Boost Clock</button>
     <button class="tab" data-tab="status" role="tab">Status</button>
     <button class="tab" data-tab="metrics" role="tab">Metrics</button>
     <button class="tab" data-tab="help" role="tab">Help</button>
   </nav>
 
   <main>
+    <!-- ======================== PERFORMANCE ======================== -->
+    <section id="tab-performance" class="panel active" role="tabpanel">
+      <div class="card intro">
+        <h2>Performance <span class="help-anchor" data-help="performance"></span></h2>
+        <p class="muted">
+          The settings that actually move performance on RDNA4. Change one thing
+          at a time and test stability. Everything lives in RAM only &mdash; a
+          reboot restores stock values.
+        </p>
+        <p id="perf-vbios-line" class="muted"></p>
+      </div>
+
+      <div class="card">
+        <h3>Power limit <span class="help-anchor" data-help="power_limit"></span></h3>
+        <p class="muted">
+          The most reliable win: give the GPU a little more power budget so it
+          holds its boost clock longer. Works without a scan.
+        </p>
+        <div class="row">
+          <label for="power-watts">Power limit (W)</label>
+          <input type="number" id="power-watts" min="100" max="400" step="1" value="340" />
+          <button id="power-btn" class="primary">Apply power limit</button>
+          <button id="power-template-btn" class="ghost">Safe template (340&nbsp;W)
+            <span class="help-anchor" data-help="power_template"></span>
+          </button>
+        </div>
+        <div class="progress hidden" id="power-progress-wrap">
+          <div class="progress-bar"><div id="power-progress" class="progress-fill"></div></div>
+          <span id="power-progress-label" class="muted"></span>
+        </div>
+        <p id="power-status" class="status muted">Stock reference is ~330&nbsp;W; ~340&nbsp;W is a safe nudge.</p>
+      </div>
+
+      <div class="card">
+        <h3>GFX clock offset <span class="help-anchor" data-help="gfx_offset"></span></h3>
+        <p class="muted">
+          A fixed MHz shift on the graphics clock (OverDrive). Needs a
+          <b>deep scan</b> first (Boost Clock tab &rarr; tick the deep-scan box).
+        </p>
+        <div class="row">
+          <label for="gfx-offset">GFX offset (MHz)</label>
+          <input type="number" id="gfx-offset" min="-1000" max="1000" step="5" value="0" />
+          <button id="gfx-offset-btn" class="primary">Apply offset</button>
+        </div>
+        <div class="progress hidden" id="gfxoff-progress-wrap">
+          <div class="progress-bar"><div id="gfxoff-progress" class="progress-fill"></div></div>
+          <span id="gfxoff-progress-label" class="muted"></span>
+        </div>
+        <p id="gfx-offset-status" class="status muted">Start small (e.g. +25&ndash;50&nbsp;MHz).</p>
+      </div>
+
+      <details class="card">
+        <summary><b>Advanced:</b> OverDrive PPT (% over default)
+          <span class="help-anchor" data-help="od_ppt"></span>
+        </summary>
+        <p class="muted">
+          The percentage-based equivalent of the power limit above. Prefer the
+          absolute watt control unless you specifically want a percentage. Needs
+          a deep scan.
+        </p>
+        <div class="row">
+          <label for="od-ppt">OD PPT (%)</label>
+          <input type="number" id="od-ppt" min="-30" max="30" step="1" value="0" />
+          <button id="od-ppt-btn" class="primary">Apply OD PPT</button>
+        </div>
+        <p id="od-ppt-status" class="status muted"></p>
+      </details>
+
+      <div class="card">
+        <h3>Activity log</h3>
+        <pre id="perf-log" class="log"></pre>
+      </div>
+    </section>
+
     <!-- ============================ HOME ============================ -->
-    <section id="tab-home" class="panel active" role="tabpanel">
+    <section id="tab-home" class="panel" role="tabpanel">
       <div class="card intro">
         <h2>Unlock your boost clock <span class="help-anchor" data-help="workflow"></span></h2>
         <p id="vbios-line" class="muted">Reading VBIOS&hellip;</p>
@@ -40,6 +115,13 @@
           </label>
           <input type="number" id="workers" min="1" max="32" value="4" />
           <button id="scan-btn" class="primary">Scan</button>
+        </div>
+        <div class="row">
+          <label class="checkbox">
+            <input type="checkbox" id="deep-scan" />
+            Enable OverDrive &amp; metrics (deep scan)
+            <span class="help-anchor" data-help="deep_scan"></span>
+          </label>
         </div>
         <div class="progress hidden" id="scan-progress-wrap">
           <div class="progress-bar"><div id="scan-progress" class="progress-fill"></div></div>

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Adrenalift</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">
+      <span class="logo">Adrenalift</span>
+      <span class="tagline">AMD GPU boost-clock unlock &mdash; web console</span>
+    </div>
+    <div class="version">v{{ app_version }} &middot; build {{ app_build }}</div>
+  </header>
+
+  <div id="banner" class="banner hidden"></div>
+
+  <nav class="tabs" role="tablist">
+    <button class="tab active" data-tab="home" role="tab">Boost Clock</button>
+    <button class="tab" data-tab="status" role="tab">Status</button>
+    <button class="tab" data-tab="metrics" role="tab">Metrics</button>
+    <button class="tab" data-tab="help" role="tab">Help</button>
+  </nav>
+
+  <main>
+    <!-- ============================ HOME ============================ -->
+    <section id="tab-home" class="panel active" role="tabpanel">
+      <div class="card intro">
+        <h2>Unlock your boost clock <span class="help-anchor" data-help="workflow"></span></h2>
+        <p id="vbios-line" class="muted">Reading VBIOS&hellip;</p>
+      </div>
+
+      <div class="card">
+        <h3>Step 1 &mdash; Scan memory <span class="help-anchor" data-help="scan"></span></h3>
+        <div class="row">
+          <label for="workers">Scan workers
+            <span class="help-anchor" data-help="scan_workers"></span>
+          </label>
+          <input type="number" id="workers" min="1" max="32" value="4" />
+          <button id="scan-btn" class="primary">Scan</button>
+        </div>
+        <div class="progress hidden" id="scan-progress-wrap">
+          <div class="progress-bar"><div id="scan-progress" class="progress-fill"></div></div>
+          <span id="scan-progress-label" class="muted"></span>
+        </div>
+        <p id="scan-status" class="status muted">Press Scan to begin.</p>
+      </div>
+
+      <div class="card">
+        <h3>Step 2 &mdash; Choose &amp; apply a boost clock
+          <span class="help-anchor" data-help="boost_clock"></span>
+        </h3>
+        <div class="row">
+          <label for="clock">Boost clock (MHz)</label>
+          <input type="number" id="clock" min="500" max="5000" step="5" value="3500" />
+          <button id="apply-btn" class="primary" disabled>Apply
+            <span class="help-anchor light" data-help="apply_simple"></span>
+          </button>
+        </div>
+        <p class="warn">
+          &#9888; Start just above stock and test for stability. Changes live in
+          RAM only and are undone by a reboot. Use at your own risk.
+        </p>
+        <div class="progress hidden" id="apply-progress-wrap">
+          <div class="progress-bar"><div id="apply-progress" class="progress-fill"></div></div>
+          <span id="apply-progress-label" class="muted"></span>
+        </div>
+      </div>
+
+      <div class="card">
+        <h3>Activity log</h3>
+        <pre id="log" class="log"></pre>
+      </div>
+    </section>
+
+    <!-- ============================ STATUS ============================ -->
+    <section id="tab-status" class="panel" role="tabpanel">
+      <div class="card">
+        <h3>GPU firmware status
+          <span class="help-anchor" data-help="status"></span>
+        </h3>
+        <button id="status-btn" class="primary">Read status</button>
+        <div id="status-result" class="result"></div>
+      </div>
+    </section>
+
+    <!-- ============================ METRICS ============================ -->
+    <section id="tab-metrics" class="panel" role="tabpanel">
+      <div class="card">
+        <h3>Live metrics
+          <span class="help-anchor" data-help="metrics"></span>
+        </h3>
+        <div class="row">
+          <button id="metrics-btn" class="primary">Read metrics</button>
+          <label class="checkbox">
+            <input type="checkbox" id="metrics-auto" />
+            Auto-refresh
+            <span class="help-anchor" data-help="metrics_auto"></span>
+          </label>
+        </div>
+        <div id="metrics-result" class="result"></div>
+      </div>
+    </section>
+
+    <!-- ============================ HELP ============================ -->
+    <section id="tab-help" class="panel" role="tabpanel">
+      <div class="help-layout">
+        <aside class="help-nav">
+          <h3>Guides</h3>
+          <ul id="help-list"></ul>
+        </aside>
+        <article id="help-body" class="card help-body">
+          <p class="muted">Select a guide on the left.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <!-- Tooltip / description popover -->
+  <div id="popover" class="popover hidden">
+    <button class="popover-close" aria-label="Close">&times;</button>
+    <div class="popover-body"></div>
+  </div>
+
+  <script src="{{ url_for('static', filename='app.js') }}"></script>
+</body>
+</html>

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -247,7 +247,17 @@
         <div class="row">
           <button id="pp-read-btn" class="primary">Load PP fields</button>
           <input type="search" id="pp-filter" placeholder="Filter fields…" />
+          <label class="checkbox">
+            <input type="checkbox" id="pp-tunable-only" checked />
+            Hide structural / read-only fields
+          </label>
         </div>
+        <p class="muted">
+          Hover a field's name for what it means; the grey line under each input
+          tells you what a valid value looks like (a 0/1 flag, MHz, mV, °C, a
+          structural offset, …). Structural fields (table layout, sizes, ids,
+          like <code>pmfw_pptable_start_offset</code>) are read-only.
+        </p>
         <div id="pp-result" class="result"><p class="muted">Press “Load PP fields”.</p></div>
         <p id="pp-status" class="status muted"></p>
       </div>

--- a/src/web/tooltips.py
+++ b/src/web/tooltips.py
@@ -70,6 +70,77 @@ TOOLTIPS: Dict[str, Tooltip] = {
             "number of CPU cores is usually a good balance."
         ),
     },
+    "deep_scan": {
+        "tip": "Also locate the GPU DMA buffer to unlock OverDrive + live metrics.",
+        "description": (
+            "A normal scan only finds the PowerPlay table, which is all the "
+            "Boost Clock patch needs. Tick <b>deep scan</b> to additionally "
+            "locate the driver's GPU DMA buffer. That unlocks the OverDrive "
+            "controls (GFX clock offset, OD PPT%) and the live Metrics tab for "
+            "the rest of the session. It is slower (it probes the GPU memory "
+            "aperture, which can take 30 seconds or more) and is only needed "
+            "once per session — the location is then remembered until you "
+            "close the server."
+        ),
+    },
+    # -- Performance tab --------------------------------------------------
+    "performance": {
+        "tip": "The handful of settings that actually move performance on RDNA4.",
+        "description": (
+            "This tab gathers the knobs that matter for real-world gains and "
+            "leaves the experimental ones elsewhere. On RDNA4 the most reliable "
+            "win is a small <b>power-limit</b> bump; the boost-clock ceiling and "
+            "GFX offset help on some cards but the driver/firmware often clamps "
+            "them back. Make one change at a time and test stability before "
+            "stacking another."
+        ),
+    },
+    "power_limit": {
+        "tip": "GPU package-power (PPT) limit in watts — the knob that reliably sticks.",
+        "description": (
+            "Raises or lowers the total board power the GPU is allowed to draw, "
+            "sent straight to the firmware (it does not need a deep scan). A "
+            "higher limit lets the card hold its boost clock longer under load, "
+            "which is usually the single most effective change on RDNA4. Stay "
+            "close to your card's stock limit: many AIB models already ship a "
+            "little higher than reference, so a modest nudge (for example a "
+            "reference 330&nbsp;W card up to ~340&nbsp;W) is a safe, well-trodden "
+            "increase. Large jumps raise heat and power draw — watch "
+            "temperatures on the Metrics tab."
+        ),
+    },
+    "power_template": {
+        "tip": "Apply the recommended safe power-limit bump.",
+        "description": (
+            "Fills in and applies a conservative power limit that is known to "
+            "be safe on most RDNA4 boards (a small step above a 330&nbsp;W "
+            "reference limit, the level several higher-tier AIB cards already "
+            "ship at). It is a starting point, not a maximum — verify "
+            "stability and temperatures, then adjust to taste."
+        ),
+    },
+    "gfx_offset": {
+        "tip": "Shift the GFX clock up or down by a fixed MHz offset (OverDrive).",
+        "description": (
+            "Applies a frequency offset to the graphics clock through the "
+            "OverDrive table. A positive offset asks for higher clocks at a "
+            "given voltage; a negative one undervolts-by-frequency for cooler, "
+            "quieter operation. This needs a <b>deep scan</b> first so the DMA "
+            "buffer is available. RDNA4 firmware may ignore or clamp large "
+            "offsets — start with a small value (e.g. +25–100&nbsp;MHz) "
+            "and confirm it took effect on the Status/Metrics tabs."
+        ),
+    },
+    "od_ppt": {
+        "tip": "Power limit as a percentage over default (OverDrive PPT).",
+        "description": (
+            "The OverDrive-table way to express a power-limit change, as a "
+            "percentage above (or below) the card's default rather than an "
+            "absolute watt figure. Prefer the absolute <b>Power limit (W)</b> "
+            "control unless you specifically want a percentage. Needs a deep "
+            "scan first."
+        ),
+    },
     # -- Boost clock ------------------------------------------------------
     "boost_clock": {
         "tip": "Target maximum boost frequency, in MHz.",
@@ -150,11 +221,62 @@ TOOLTIPS: Dict[str, Tooltip] = {
 
 # Friendly one-line summaries shown in the help navigation list.  Order here
 # defines the order the pages appear in the UI.
+# A page entry uses either ``const`` (pulled from src.app.help_texts) or
+# ``html`` (inline, defined here for web-only pages such as Performance).
+PERFORMANCE_HELP_HTML = """
+<h3>Settings that actually matter for performance</h3>
+<p>Adrenalift exposes a lot of knobs, but on RDNA4 only a few make a
+dependable difference. Here is what to reach for, in order.</p>
+
+<h4>1. Power limit (PPT) &mdash; the reliable one</h4>
+<p>The graphics driver and SMU firmware aggressively clamp clocks back to
+their idea of "allowed", so raising a clock ceiling often does nothing visible.
+What the firmware <i>does</i> honour is the <b>power limit</b>. Giving the card
+a little more power budget lets it sustain its boost clock longer under load,
+which is the most consistent real-world gain. Many partner cards (Red Devil,
+Taichi, etc.) already ship above the reference limit, so nudging a reference
+330&nbsp;W board to about <b>340&nbsp;W</b> is a safe, validated step that
+other brands allow out of the box. Use the <b>Power limit (W)</b> control (or
+the one-click safe template).</p>
+
+<h4>2. Boost clock ceiling</h4>
+<p>The original feature: patch the driver's cached PowerPlay table so the GPU
+is <i>allowed</i> to reach a higher boost clock. On some cards this helps; on
+many RDNA4 cards the firmware still clamps the result. Harmless to try &mdash;
+scan, set a value slightly above stock, apply, and check whether clocks under
+load actually rise.</p>
+
+<h4>3. GFX clock offset (OverDrive)</h4>
+<p>A fixed MHz shift applied through the OverDrive table. A small positive
+offset can squeeze out a little more frequency; a small negative offset acts
+as a frequency-based undervolt for lower temperatures and noise. Requires a
+<b>deep scan</b> so the DMA buffer is available, and large offsets are often
+ignored &mdash; keep it modest.</p>
+
+<h4>A safe starting template</h4>
+<ul>
+  <li><b>Power limit:</b> stock + ~10&nbsp;W (e.g. 330&nbsp;&rarr;&nbsp;340&nbsp;W).</li>
+  <li><b>Boost clock:</b> optional, +50\u2013100&nbsp;MHz over stock, only if it
+      measurably helps.</li>
+  <li><b>GFX offset:</b> 0 to start; try +25\u201350&nbsp;MHz once the above is
+      stable.</li>
+</ul>
+<p>Change one thing at a time, run a real workload, and watch temperatures and
+the throttling readout on the <b>Metrics</b> tab. Everything here lives only in
+RAM &mdash; a reboot restores stock values.</p>
+"""
+
 _HELP_PAGES_META: List[Dict[str, str]] = [
+    {
+        "id": "performance",
+        "title": "Performance settings that matter",
+        "summary": "Start here \u2014 the few knobs that actually help on RDNA4.",
+        "html": PERFORMANCE_HELP_HTML,
+    },
     {
         "id": "how_it_works",
         "title": "How Adrenalift works",
-        "summary": "Start here \u2014 what scanning and applying actually do.",
+        "summary": "What scanning and applying actually do.",
         "const": "SIMPLE_HOW_IT_WORKS_HTML",
     },
     {
@@ -220,7 +342,9 @@ def _load_help_html() -> Dict[str, str]:
         return {}
     out: Dict[str, str] = {}
     for meta in _HELP_PAGES_META:
-        out[meta["const"]] = getattr(help_texts, meta["const"], "")
+        const = meta.get("const")
+        if const:
+            out[const] = getattr(help_texts, const, "")
     return out
 
 
@@ -229,12 +353,14 @@ def help_pages() -> List[Dict[str, str]]:
     html_by_const = _load_help_html()
     pages: List[Dict[str, str]] = []
     for meta in _HELP_PAGES_META:
+        # Inline ``html`` (web-only pages) wins; otherwise pull from help_texts.
+        body = meta.get("html") or html_by_const.get(meta.get("const", ""), "")
         pages.append(
             {
                 "id": meta["id"],
                 "title": meta["title"],
                 "summary": meta["summary"],
-                "html": html_by_const.get(meta["const"], ""),
+                "html": body,
             }
         )
     return pages

--- a/src/web/tooltips.py
+++ b/src/web/tooltips.py
@@ -202,6 +202,89 @@ TOOLTIPS: Dict[str, Tooltip] = {
             "freeze the current snapshot or to reduce background SMU traffic."
         ),
     },
+    # -- Profiles ---------------------------------------------------------
+    "profiles": {
+        "tip": "Save, export, import and re-apply bundles of tuning settings.",
+        "description": (
+            "A profile is a saved recipe of your settings (power limit, boost "
+            "clock, GFX offset, OD PPT, …). <b>Save current</b> writes the "
+            "Performance-tab values to a file; <b>Apply</b> pushes a saved "
+            "profile to the GPU; <b>Export</b>/<b>Import</b> move the file "
+            "between machines. Profiles deliberately never contain the "
+            "persistent registry tweaks, and nothing is applied automatically "
+            "on boot — so a reboot always returns the GPU to stock and you "
+            "re-apply the profile yourself."
+        ),
+    },
+    # -- OverDrive table --------------------------------------------------
+    "overdrive": {
+        "tip": "The firmware OverDrive table: clocks, voltage, power, fan, temps.",
+        "description": (
+            "The full set of OverDrive knobs the SMU exposes — GFX/UCLK/FCLK "
+            "offsets and limits, voltage maxima, PPT/TDC percentages, fan curve "
+            "and temperature targets. Each field is read live and applied "
+            "individually. This needs a <b>deep scan</b> first (to locate the "
+            "DMA buffer). RDNA4 firmware may clamp aggressive values; change one "
+            "at a time. Everything reverts on reboot."
+        ),
+    },
+    # -- PowerPlay editor -------------------------------------------------
+    "powerplay": {
+        "tip": "Per-field editor for the driver's cached PowerPlay table (RAM).",
+        "description": (
+            "Shows every field Adrenalift can decode from your VBIOS PowerPlay "
+            "table. Setting a field writes that value into the driver's cached "
+            "copy in RAM across all scanned addresses (run a <b>Scan</b> first). "
+            "This is a power-user tool — incorrect values can crash the "
+            "driver or corrupt the display. As always, a reboot restores the "
+            "stock table."
+        ),
+    },
+    # -- SMU controls -----------------------------------------------------
+    "freq_limits": {
+        "tip": "Pin the GFX clock to a min/max MHz window.",
+        "description": (
+            "Sends soft and hard min/max frequency limits for the graphics "
+            "clock straight to the firmware. Use a min to stop the card "
+            "downclocking at idle, or a max to cap it. Leave a field at 0 to "
+            "leave it unchanged. Reverts on reboot."
+        ),
+    },
+    "power_lock": {
+        "tip": "Disable the idle/clock-gating features that cause downclocking.",
+        "description": (
+            "Turns off DS_GFXCLK, GFX_ULV and GFXOFF — the power-saving "
+            "features that let the GPU drop its clocks when it thinks it is "
+            "idle. Locking them can keep clocks high for benchmarking but raises "
+            "idle power and heat. <b>Unlock</b> restores stock behaviour; so "
+            "does a reboot."
+        ),
+    },
+    # -- Escape -----------------------------------------------------------
+    "escape": {
+        "tip": "Apply OD via the WDDM D3DKMTEscape path — no admin needed.",
+        "description": (
+            "An alternative way to push OD settings, using the same "
+            "D3DKMTEscape OD8 interface AMD's own Adrenalin software uses at "
+            "runtime. It does not require Administrator privileges. Only the "
+            "high-level knobs that map to OD8 entries are exposed (clock "
+            "ceiling, power, GFX offset); leave a field at 0 to skip it. Effects "
+            "are volatile and reset on reboot."
+        ),
+    },
+    # -- Registry (persistent) -------------------------------------------
+    "registry": {
+        "tip": "Persistent driver registry tweaks — these survive a reboot!",
+        "description": (
+            "Disables driver-level power-saving / clock-gating behaviour by "
+            "writing values under the GPU's registry key. <b>Unlike everything "
+            "else in Adrenalift, these persist across reboots.</b> A backup is "
+            "taken before the first apply; press <b>Restore</b> (or shut the "
+            "server down cleanly, which auto-restores) to revert. A hard crash "
+            "or power loss will not auto-revert — use Restore. These are "
+            "intentionally kept out of profiles."
+        ),
+    },
     # -- VBIOS ------------------------------------------------------------
     "vbios": {
         "tip": "Stock clock and power values read from your card's VBIOS ROM.",
@@ -266,12 +349,46 @@ the throttling readout on the <b>Metrics</b> tab. Everything here lives only in
 RAM &mdash; a reboot restores stock values.</p>
 """
 
+EPHEMERAL_HELP_HTML = """
+<h3>Ephemeral by design</h3>
+<p>Almost everything Adrenalift does lives only in volatile state &mdash; the
+driver's in-RAM PowerPlay table, the SMU's runtime settings, the OverDrive
+table, the D3DKMTEscape path. <b>A reboot wipes all of it and returns your GPU
+to stock.</b> That is deliberate: it makes aggressive experiments safe to back
+out of &mdash; if something misbehaves, just restart.</p>
+
+<h4>The one exception: registry tweaks (System tab)</h4>
+<p>The <b>System</b> tab's registry/ULPS tweaks are different: they write to the
+Windows registry and <b>survive a reboot</b>. To keep them manageable:</p>
+<ul>
+  <li>They are <b>never</b> stored in a profile.</li>
+  <li>A backup is taken before the first apply.</li>
+  <li>There is a <b>Restore</b> button, and a clean server shutdown
+      auto-restores them.</li>
+  <li>A hard crash or power loss cannot auto-revert &mdash; use Restore (the
+      backup file is kept for exactly that).</li>
+</ul>
+
+<h4>Profiles</h4>
+<p>Profiles are saved <i>recipes</i>. Saving or exporting writes a JSON file to
+disk &mdash; that is the point. But applying a profile only ever changes the
+volatile state above, and there is no &ldquo;apply on startup&rdquo; option, so
+the ephemeral guarantee holds: after a reboot the GPU is at stock and you
+re-apply the profile yourself whenever you want it back.</p>
+"""
+
 _HELP_PAGES_META: List[Dict[str, str]] = [
     {
         "id": "performance",
         "title": "Performance settings that matter",
         "summary": "Start here \u2014 the few knobs that actually help on RDNA4.",
         "html": PERFORMANCE_HELP_HTML,
+    },
+    {
+        "id": "ephemeral",
+        "title": "Ephemeral by design",
+        "summary": "What reverts on reboot, what persists, and how profiles fit.",
+        "html": EPHEMERAL_HELP_HTML,
     },
     {
         "id": "how_it_works",

--- a/src/web/tooltips.py
+++ b/src/web/tooltips.py
@@ -1,0 +1,245 @@
+"""Beginner-friendly tooltips and descriptions for the Adrenalift web UI.
+
+The desktop GUI scatters short ``setToolTip(...)`` strings across many tab
+modules and keeps long-form explanations in :mod:`src.app.help_texts`.  The web
+front-end needs that guidance in one structured, data-driven place so it can be
+rendered consistently (hover tooltips + expandable "Learn more" descriptions)
+for users who are *not* GPU-overclocking experts.
+
+This module therefore does two things:
+
+1. Defines :data:`TOOLTIPS` -- a mapping of UI element ids to a short hover
+   ``tip`` and a longer plain-language ``description``.  These intentionally
+   re-use and *extend* the wording from the desktop tooltips so behaviour stays
+   familiar while reading more clearly for regular users.
+
+2. Re-exports the long-form HTML cheat-sheets from
+   :mod:`src.app.help_texts` as a list of navigable help pages
+   (:func:`help_pages`), each with a friendly summary line.
+
+Nothing here imports Qt, so it is safe to use from the web server (and is fully
+testable on any platform).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, TypedDict
+
+
+class Tooltip(TypedDict):
+    tip: str
+    description: str
+
+
+# ---------------------------------------------------------------------------
+# Short hover tip + longer "Learn more" description for each web UI control.
+# Keys are referenced by templates/static JS via ``data-help="<key>"``.
+# ---------------------------------------------------------------------------
+
+TOOLTIPS: Dict[str, Tooltip] = {
+    # -- Global / workflow ------------------------------------------------
+    "workflow": {
+        "tip": "The usual order is: Scan \u2192 set a Boost Clock \u2192 Apply.",
+        "description": (
+            "Adrenalift raises the boost-clock ceiling that the AMD driver "
+            "normally enforces. You generally follow three steps: first "
+            "<b>Scan</b> so the tool can locate the driver's clock table in "
+            "memory, then choose a <b>Boost Clock</b> target, then press "
+            "<b>Apply</b>. Changes live only in RAM, so a reboot always "
+            "restores the stock values."
+        ),
+    },
+    "scan": {
+        "tip": "Search system memory for the driver's PowerPlay clock table.",
+        "description": (
+            "Scanning looks through physical memory for the AMD driver's "
+            "cached <b>PowerPlay (PP) table</b> \u2014 the table that holds "
+            "the clock limits the driver is willing to enforce. The tool needs "
+            "to know exactly where that table lives before it can patch it, so "
+            "run a scan once per session (or after a driver reset). A scan can "
+            "take from a few seconds to a minute depending on how much RAM is "
+            "installed and how many worker threads you use."
+        ),
+    },
+    "scan_workers": {
+        "tip": "How many threads scan memory in parallel.",
+        "description": (
+            "More workers finish the memory scan faster but put a heavier "
+            "load on your system while the scan runs. If your machine becomes "
+            "unresponsive during a scan, lower this number. A value around the "
+            "number of CPU cores is usually a good balance."
+        ),
+    },
+    # -- Boost clock ------------------------------------------------------
+    "boost_clock": {
+        "tip": "Target maximum boost frequency, in MHz.",
+        "description": (
+            "This is the new ceiling you want the GPU to be allowed to reach. "
+            "Start only slightly above your card's stock boost clock and test "
+            "for stability before going higher \u2014 raising it too far can "
+            "cause crashes, display corruption, or a driver reset. The value is "
+            "written into the driver's cached clock table; the GPU will boost "
+            "up to it when power and temperature allow, not constantly."
+        ),
+    },
+    "apply_simple": {
+        "tip": "Write the chosen Boost Clock into the driver's table and activate it.",
+        "description": (
+            "Apply does three things in order: (1) it overwrites the "
+            "GameClock and BoostClock fields in the driver's in-RAM table with "
+            "your value, (2) it tells the GPU firmware not to sleep so the new "
+            "limit takes effect immediately, and (3) it nudges the driver to "
+            "re-read its table so your value is pushed to the hardware right "
+            "away. Nothing is written to disk, so the change is reverted by a "
+            "reboot. A successful Scan is required first."
+        ),
+    },
+    "save_default_clock": {
+        "tip": "Remember this Boost Clock value for the next launch.",
+        "description": (
+            "Stores the current Boost Clock so it is pre-filled the next time "
+            "you open Adrenalift. It does not apply the value \u2014 you still "
+            "press Apply to activate it."
+        ),
+    },
+    # -- Status / metrics -------------------------------------------------
+    "status": {
+        "tip": "Read live GPU firmware (SMU) state: clocks, power limit, features.",
+        "description": (
+            "Queries the GPU's System Management Unit (SMU) for its current "
+            "minimum/maximum clock limits per domain, the active power (PPT) "
+            "limit, voltage, and which firmware feature flags are enabled. Use "
+            "it to confirm an overclock took effect or to inspect the card's "
+            "current operating envelope. This is read-only and changes nothing."
+        ),
+    },
+    "metrics": {
+        "tip": "Live sensor readout: clocks, power, temperatures, fan, activity.",
+        "description": (
+            "Shows the GPU's real-time telemetry pulled straight from the SMU "
+            "metrics table \u2014 current clocks, board power, temperatures, "
+            "fan speed, utilisation, and throttling reasons. Reading metrics "
+            "requires the DMA buffer to be available; if it isn't, run a DRAM "
+            "scan in the desktop app first. This view is read-only."
+        ),
+    },
+    "metrics_auto": {
+        "tip": "Automatically refresh the live metrics every couple of seconds.",
+        "description": (
+            "When enabled, the metrics table re-reads the GPU sensors on a "
+            "timer so you can watch values change under load. Turn it off to "
+            "freeze the current snapshot or to reduce background SMU traffic."
+        ),
+    },
+    # -- VBIOS ------------------------------------------------------------
+    "vbios": {
+        "tip": "Stock clock and power values read from your card's VBIOS ROM.",
+        "description": (
+            "Adrenalift reads a dump of your card's VBIOS to learn the factory "
+            "default clocks and limits. These act as a baseline and a sanity "
+            "check while scanning. If no valid ROM is found the tool falls "
+            "back to built-in defaults, which still work but are less precise."
+        ),
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Long-form help pages (re-using the existing desktop cheat-sheets).
+# ---------------------------------------------------------------------------
+
+# Friendly one-line summaries shown in the help navigation list.  Order here
+# defines the order the pages appear in the UI.
+_HELP_PAGES_META: List[Dict[str, str]] = [
+    {
+        "id": "how_it_works",
+        "title": "How Adrenalift works",
+        "summary": "Start here \u2014 what scanning and applying actually do.",
+        "const": "SIMPLE_HOW_IT_WORKS_HTML",
+    },
+    {
+        "id": "status",
+        "title": "Reading GPU status",
+        "summary": "What the SMU version, clocks and limits mean.",
+        "const": "STATUS_CHEATSHEET",
+    },
+    {
+        "id": "clocks",
+        "title": "Clocks explained",
+        "summary": "GFX, memory, fabric and SoC clock domains.",
+        "const": "CLOCK_CHEATSHEET",
+    },
+    {
+        "id": "metrics",
+        "title": "Live metrics glossary",
+        "summary": "Every sensor in the metrics readout, in plain terms.",
+        "const": "METRICS_CHEATSHEET",
+    },
+    {
+        "id": "controls",
+        "title": "Advanced controls",
+        "summary": "OverDrive offsets, power and temperature limits.",
+        "const": "CONTROLS_CHEATSHEET",
+    },
+    {
+        "id": "features",
+        "title": "SMU feature flags",
+        "summary": "What the firmware feature bits do.",
+        "const": "FEATURES_CHEATSHEET",
+    },
+    {
+        "id": "throttlers",
+        "title": "Throttlers",
+        "summary": "Why the GPU holds back, and the throttler mask.",
+        "const": "THROTTLERS_CHEATSHEET",
+    },
+    {
+        "id": "pp",
+        "title": "PowerPlay table editor",
+        "summary": "The full PP table field editor (power users).",
+        "const": "PP_HELP_HTML",
+    },
+    {
+        "id": "registry",
+        "title": "Registry tweaks",
+        "summary": "ULPS and clock-gating registry keys.",
+        "const": "REG_CHEATSHEET_HTML",
+    },
+]
+
+
+def _load_help_html() -> Dict[str, str]:
+    """Return ``{const_name: html}`` from :mod:`src.app.help_texts`.
+
+    Imported lazily and defensively: a missing constant simply yields an empty
+    string so the help page degrades gracefully instead of breaking the UI.
+    """
+    try:
+        from src.app import help_texts
+    except Exception:  # pragma: no cover - only if help_texts import breaks
+        return {}
+    out: Dict[str, str] = {}
+    for meta in _HELP_PAGES_META:
+        out[meta["const"]] = getattr(help_texts, meta["const"], "")
+    return out
+
+
+def help_pages() -> List[Dict[str, str]]:
+    """Return navigable help pages with friendly summaries and HTML bodies."""
+    html_by_const = _load_help_html()
+    pages: List[Dict[str, str]] = []
+    for meta in _HELP_PAGES_META:
+        pages.append(
+            {
+                "id": meta["id"],
+                "title": meta["title"],
+                "summary": meta["summary"],
+                "html": html_by_const.get(meta["const"], ""),
+            }
+        )
+    return pages
+
+
+def tooltips() -> Dict[str, Tooltip]:
+    """Return the full tooltip / description map."""
+    return TOOLTIPS

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-    "version":  "0.1.4",
+    "version":  "0.1.5",
     "build":  1
 }

--- a/web.bat
+++ b/web.bat
@@ -1,0 +1,21 @@
+@echo off
+REM Launch the Adrenalift web server (browser front-end).
+REM Requires: pip install -r requirements.txt  (installs Flask)
+REM Hardware actions require Administrator privileges.
+
+cd /d "%~dp0"
+
+REM Prefer python, fall back to py launcher (common on Windows)
+where python >nul 2>nul && set PY=python || set PY=py
+
+echo Checking dependencies...
+%PY% -c "import flask" 2>nul || (
+    echo Installing requirements...
+    %PY% -m pip install -r requirements.txt
+)
+
+echo.
+echo Starting Adrenalift web server on http://127.0.0.1:8770
+echo Open that address in your browser. Press Ctrl+C to stop.
+echo.
+%PY% -m src.web %*


### PR DESCRIPTION
## Summary

Two things, building on the recent web-server refactor:

1. **A build script for a standalone web-console `.exe`** you can run on Windows. The previous build tooling only produced the desktop GUI; this adds a PyInstaller build for the browser front-end.
2. **Full web control of the performance-relevant knobs**, gathered into a dedicated **Performance** tab, with rich tooltips/help — including the one that actually works on RDNA4 in practice: **raising the power limit**.

## Web-console exe

- `build_web.spec`, `build_web.bat`, `build_web.ps1` — PyInstaller onefile for the web server. Bundles the HTML/CSS/JS assets + Flask, excludes Qt, keeps a console window, requests admin elevation. Output: `dist/Adrenalift_Web_<ver>_<build>.exe`.
- `src/web/exe_entry.py` — frozen entry point: starts the server and opens the default browser.
- `server.create_app()` now resolves `templates/`/`static/` via `sys._MEIPASS` when frozen (otherwise Flask can't find them in a onefile build).

Run: `.\build_web.ps1` → run the exe as Administrator → it opens `http://127.0.0.1:8770`.

## Performance tab (new default tab)

The settings that actually move performance on RDNA4, in one place:

- **Power limit (W)** — sent straight to the firmware via SMU `SetPptLimit`; **no DMA buffer / deep scan required**. This is the reliable win (e.g. a 330 W reference card → ~340 W, the level several AIB cards already ship at). One-click **safe template** button included.
- **GFX clock offset (MHz)** and **OverDrive PPT %** — via the OverDrive table (need a deep scan first).
- A **deep-scan** checkbox on the Boost Clock tab additionally locates the GPU DMA buffer, unlocking the OverDrive controls + live Metrics for the session.

New endpoints (`/api/apply/power_limit`, `/api/apply/gfx_offset`, `/api/apply/od_ppt`) are thin wrappers over existing, already-used engine functions, with input-range validation. Hardware errors still return only controlled, human-authored messages (added `power_limit_failed` / `od_failed` codes) — no exception text reaches the client.

## Docs & help

- Tooltips/descriptions for every new control.
- New inline **"Performance settings that matter"** help page explaining why the power limit is the dependable RDNA4 knob and giving a safe starting template.
- README updated with web-exe build steps and Performance-tab docs.

## How the unlock works (context for the power-limit emphasis)

The driver/SMU clamp raw clock ceilings back to their own policy, so PP-table boost-clock patches and clock offsets are often ignored on RDNA4. What the firmware reliably honours is the **power budget** — more PPT lets the card hold boost longer under load. That matches the reporter's experience (only 330→340 W sticks), so the Performance tab leads with it.

## Testing

- Server boots and serves the full UI off-Windows (graceful "engine unavailable" degradation verified).
- `/api/state`, `/api/help`, and the new apply endpoints exercised: range validation returns 400, missing hardware surfaces the safe controlled error via the job snapshot (no leak), unknown job → 404.
- Python syntax + imports validated for all changed modules and the spec.
- ⚠️ **Hardware paths (power-limit/offset/OD writes) could not be tested here** — they need a Windows host with an AMD GPU. They wrap existing engine functions, but please verify on your card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)